### PR TITLE
Improve route label spacing and directional marker tail

### DIFF
--- a/src/transitmap/config/ConfigReader.cpp
+++ b/src/transitmap/config/ConfigReader.cpp
@@ -52,6 +52,8 @@ void ConfigReader::help(const char *bin) const {
             << "width of line outlines\n"
             << std::setw(37) << "  --render-dir-markers"
             << "render line direction markers\n"
+            << std::setw(37) << "  --render-markers-tail"
+            << "add tail to direction markers\n"
             << std::setw(37) << "  -l [ --labels ]"
             << "render labels\n"
             << std::setw(37) << "  -r [ --route-labels ]"
@@ -106,6 +108,7 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
                          {"route-labels", no_argument, 0, 'r'},
                          {"tight-stations", no_argument, 0, 9},
                          {"render-dir-markers", no_argument, 0, 10},
+                         {"render-markers-tail", no_argument, 0, 20},
                          {"no-render-node-connections", no_argument, 0, 11},
                          {"resolution", required_argument, 0, 12},
                          {"padding", required_argument, 0, 13},
@@ -160,6 +163,9 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
       break;
     case 10:
       cfg->renderDirMarkers = true;
+      break;
+    case 20:
+      cfg->renderMarkersTail = true;
       break;
     case 11:
       cfg->renderNodeConnections = false;

--- a/src/transitmap/config/TransitMapConfig.h
+++ b/src/transitmap/config/TransitMapConfig.h
@@ -49,6 +49,7 @@ struct Config {
   std::vector<size_t> mvtZooms;
 
   bool renderDirMarkers = false;
+  bool renderMarkersTail = false;
   std::string worldFilePath;
 };
 

--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -573,11 +573,22 @@ void SvgRenderer::renderEdgeTripGeom(const RenderGraph &outG,
       PolyLine<double> secondPart =
           p.getSegmentAtDist(p.getLength() / 2, p.getLength());
 
+      double tailWorld = 15.0 / _cfg->outputResolution;
       if (lo.direction == e->getTo()) {
+        if (_cfg->renderMarkersTail) {
+          PolyLine<double> tail =
+              secondPart.getSegmentAtDist(0, std::min(tailWorld, secondPart.getLength()));
+          renderLinePart(tail, lineW, *line, "stroke:black", "stroke:none");
+        }
         renderLinePart(firstPart, lineW, *line, css, oCss,
                        markerName.str() + "_m");
         renderLinePart(secondPart.reversed(), lineW, *line, css, oCss);
       } else {
+        if (_cfg->renderMarkersTail) {
+          PolyLine<double> tail = firstPart.reversed().getSegmentAtDist(
+              0, std::min(tailWorld, firstPart.getLength()));
+          renderLinePart(tail, lineW, *line, "stroke:black", "stroke:none");
+        }
         renderLinePart(secondPart.reversed(), lineW, *line, css, oCss,
                        markerName.str() + "_m");
         renderLinePart(firstPart, lineW, *line, css, oCss);
@@ -945,11 +956,15 @@ void SvgRenderer::renderTerminusLabels(const RenderGraph &g,
     double boxW = 5 * charW + pad * 2; // uniform width for up to 4 chars
 
     size_t idx = 0;
+    double gapAbove = pad * 0.5;
+    double gapBelow = pad * 1.5;
+    double startY = above ? y - boxH - gapAbove : y + gapBelow;
+    double step = boxH + (above ? gapAbove : gapBelow);
+
     for (auto line : lines) {
       std::string label = line->label();
       double rectX = x - boxW / 2;
-      double rectY =
-          above ? y - (idx + 1) * (boxH + pad) : y + pad + idx * (boxH + pad);
+      double rectY = above ? startY - idx * step : startY + idx * step;
 
       std::string fillColor = line->color();  // e.g. "ffcc00"
       std::string textColor = isLightColor(fillColor) ? "black" : "white";


### PR DESCRIPTION
## Summary
- Adjust terminus route label positioning to balance spacing above and below station labels
- Add optional tail for directional markers via `--render-markers-tail`

## Testing
- `cmake -S . -B build` *(fails: The source directory /workspace/loom/src/util does not contain a CMakeLists.txt file)*

------
https://chatgpt.com/codex/tasks/task_e_68a414f6ceb0832da105377b86093594