### PR TITLE
Improve station label placement

### DIFF
--- a/src/transitmap/label/Labeller.cpp
+++ b/src/transitmap/label/Labeller.cpp
@@ -114,6 +114,12 @@ void Labeller::labelStations(const RenderGraph& g, bool notdeg2) {
     if (cands.size() == 0) continue;
 
     auto cand = cands.front();
+    for (const auto& c : cands) {
+      if (c.deg % 6 == 0 || c.deg % 6 == 3) {
+        cand = c;
+        break;
+      }
+    }
     _stationLabels.push_back(cand);
     _statLblIdx.add(cand.band, _stationLabels.size() - 1);
   }
@@ -125,7 +131,7 @@ Overlaps Labeller::getOverlaps(const util::geo::MultiLine<double>& band,
                                const RenderGraph& g) const {
   std::set<const shared::linegraph::LineEdge*> proced;
 
-  Overlaps ret{0, 0, 0, 0};
+  Overlaps ret{0, 0, 0, 0, 0};
 
   std::set<const shared::linegraph::LineNode*> procedNds{forNd};
 
@@ -169,7 +175,12 @@ Overlaps Labeller::getOverlaps(const util::geo::MultiLine<double>& band,
 
   for (auto id : labelNeighs) {
     auto labelNeigh = _stationLabels[id];
-    if (util::geo::dist(labelNeigh.band, band) < 1) ret.statLabelOverlaps++;
+    if (util::geo::dist(labelNeigh.band, band) < 1) {
+      if (labelNeigh.bold)
+        ret.termLabelOverlaps++;
+      else
+        ret.statLabelOverlaps++;
+    }
   }
 
   return ret;

--- a/src/transitmap/label/Labeller.h
+++ b/src/transitmap/label/Labeller.h
@@ -34,6 +34,7 @@ struct Overlaps {
   size_t lineLabelOverlaps;
   size_t statLabelOverlaps;
   size_t statOverlaps;
+  size_t termLabelOverlaps;
 };
 
 inline bool statNdCmp(const shared::linegraph::LineNode* a,
@@ -63,7 +64,8 @@ struct StationLabel {
   double getPen() const {
     double score = overlaps.lineOverlaps * 15 + overlaps.statOverlaps * 20 +
                    overlaps.statLabelOverlaps * 20 +
-                   overlaps.lineLabelOverlaps * 15;
+                   overlaps.lineLabelOverlaps * 15 +
+                   overlaps.termLabelOverlaps * 10;
     score += DEG_PENS[deg];
 
     if (pos == 0) score += 0.5;


### PR DESCRIPTION
## Summary
- Track overlaps with terminus labels separately and penalize them lightly
- Prefer horizontal or vertical station label orientations before angled ones

## Testing
- `cmake -S . -B build` (fails: The source directory /workspace/loom/src/util does not contain a CMakeLists.txt file)


------
https://chatgpt.com/codex/tasks/task_e_68a423152ab4832d9a829ef3fafca75b