### PR TITLE
Prefer station labels on correct side of the road

### DIFF
--- a/src/transitmap/label/Labeller.cpp
+++ b/src/transitmap/label/Labeller.cpp
@@ -5,6 +5,7 @@
 #include "shared/rendergraph/RenderGraph.h"
 #include "transitmap/label/Labeller.h"
 #include "util/geo/Geo.h"
+#include <cmath>
 
 using shared::rendergraph::RenderGraph;
 using transitmapper::label::Labeller;
@@ -90,6 +91,18 @@ void Labeller::labelStations(const RenderGraph& g, bool notdeg2) {
 
   for (auto n : orderedNds) {
     double fontSize = _cfg->stationLabelSize;
+    int prefDeg = 0;
+    if (n->pl().stops().size()) {
+      const auto& sp = n->pl().stops().front().pos;
+      const auto* cp = n->pl().getGeom();
+      double dx = sp.getX() - cp->getX();
+      double dy = sp.getY() - cp->getY();
+      if (std::abs(dx) > 1e-9 || std::abs(dy) > 1e-9) {
+        double ang = std::atan2(dy, dx) * 180.0 / M_PI;
+        prefDeg = static_cast<int>(std::round(ang / 30.0));
+        prefDeg = (prefDeg % 12 + 12) % 12;
+      }
+    }
 
     std::vector<StationLabel> cands;
 
@@ -104,9 +117,12 @@ void Labeller::labelStations(const RenderGraph& g, bool notdeg2) {
                 overlaps.statOverlaps >
             0)
           continue;
-        cands.push_back({PolyLine<double>(band[0]), band, fontSize,
-                         g.isTerminus(n), deg, offset, overlaps,
-                         n->pl().stops().front()});
+        size_t diff = (deg + 12 - prefDeg) % 12;
+        if (diff > 6) diff = 12 - diff;
+        double sidePen = static_cast<double>(diff) * 5.0;
+        cands.push_back(StationLabel{PolyLine<double>(band[0]), band, fontSize,
+                                     g.isTerminus(n), deg, offset, overlaps,
+                                     sidePen, n->pl().stops().front()});
       }
     }
 

--- a/src/transitmap/label/Labeller.h
+++ b/src/transitmap/label/Labeller.h
@@ -59,6 +59,9 @@ struct StationLabel {
   size_t pos;
   Overlaps overlaps;
 
+  // penalty to discourage placing labels on the wrong side of the road
+  double sidePen = 0;
+
   shared::linegraph::Station s;
 
   double getPen() const {
@@ -66,7 +69,9 @@ struct StationLabel {
                    overlaps.statLabelOverlaps * 20 +
                    overlaps.lineLabelOverlaps * 15 +
                    overlaps.termLabelOverlaps * 10;
-    score += DEG_PENS[deg];
+    // wrap deg to the penalty table size to avoid out of bounds access
+    score += DEG_PENS[deg % DEG_PENS.size()];
+    score += sidePen;
 
     if (pos == 0) score += 0.5;
     if (pos == 2) score += 0.1;


### PR DESCRIPTION
## Summary
- Bias station label placement towards the stop's side of the street
- Guard against out-of-range degree penalties when evaluating label orientations
- Fix StationLabel candidate initialization so builds succeed

## Testing
- `git submodule update --init --recursive` *(fails: unable to access submodule URLs: CONNECT tunnel failed, response 403)*
- `cmake -S . -B build` *(fails: src/util and src/cppgtfs missing CMakeLists.txt)*

------
https://chatgpt.com/codex/tasks/task_e_68a5516ee9e8832d9e7f11392305d3a5