### PR TITLE
Improve station label fallback placement

### DIFF
--- a/src/transitmap/label/Labeller.h
+++ b/src/transitmap/label/Labeller.h
@@ -130,7 +130,7 @@ class Labeller {
 
   util::geo::MultiLine<double> getStationLblBand(
       const shared::linegraph::LineNode* n, double fontSize, uint8_t offset,
-      const shared::rendergraph::RenderGraph& g);
+      size_t labelLen, const shared::rendergraph::RenderGraph& g);
 };
 }  // namespace label
 }  // namespace transitmapper


### PR DESCRIPTION
## Summary
- Allow station label band to consider actual label length
- Retry station label placement with reduced font size and truncated text when overlap prevents rendering

## Testing
- `cmake .. && make -j4` *(fails: missing util and cppgtfs subdirectories)*

------
https://chatgpt.com/codex/tasks/task_e_68a5651a5168832dbc4a96d95f60d7b0