### PR TITLE
Prevent collapsing reverse edges in topology builder

### DIFF
--- a/src/topo/mapconstructor/MapConstructor.cpp
+++ b/src/topo/mapconstructor/MapConstructor.cpp
@@ -46,6 +46,13 @@ bool MapConstructor::lineEq(const LineEdge* a, const LineEdge* b) {
   if (a->pl().getLines().size() != b->pl().getLines().size()) return false;
 
   const auto shrNd = LineGraph::sharedNode(a, b);
+  if (!shrNd) return false;
+
+  // If both edges connect the shared node to the same other node, they form
+  // a back-and-forth traversal over the exact same segment. In that case we
+  // must not collapse them into a single edge, otherwise both directions would
+  // be merged and could not be rendered separately.
+  if (a->getOtherNd(shrNd) == b->getOtherNd(shrNd)) return false;
 
   for (const auto& ra : a->pl().getLines()) {
     if (!b->pl().hasLine(ra.line)) return false;
@@ -57,7 +64,13 @@ bool MapConstructor::lineEq(const LineEdge* a, const LineEdge* b) {
     bool found = false;
 
     if (ra.direction == 0 && rb.direction == 0) {
-      found = true;
+      // Only treat the edges as equal if one enters the shared node and the
+      // other leaves it. This avoids collapsing parallel edges that simply
+      // connect to the same node.
+      if ((a->getTo() == shrNd && b->getFrom() == shrNd) ||
+          (a->getFrom() == shrNd && b->getTo() == shrNd)) {
+        found = true;
+      }
     }
     if (ra.direction == shrNd && rb.direction != 0 && rb.direction != shrNd) {
       found = true;


### PR DESCRIPTION
## Summary
- avoid merging edges representing back-and-forth segments so each direction can render separately

## Testing
- `cmake ..` *(fails: The source directory `/workspace/loom/src/util` does not contain a CMakeLists.txt file)*

------
https://chatgpt.com/codex/tasks/task_e_68a6dff8b0bc832db8e800f246e2f88f