### PR TITLE
Fix terminus label assignment to match actual route endpoints

### DIFF
--- a/src/shared/linegraph/LineGraph.cpp
+++ b/src/shared/linegraph/LineGraph.cpp
@@ -1286,6 +1286,22 @@ bool LineGraph::terminatesAt(const LineEdge* fromEdge, const LineNode* terminus,
 }
 
 // _____________________________________________________________________________
+bool LineGraph::terminatesAt(const LineNode* n, const Line* line) {
+  bool occurs = false;
+  for (auto fromEdge : n->getAdjList()) {
+    if (!fromEdge->pl().hasLine(line)) continue;
+    occurs = true;
+    for (auto toEdge : n->getAdjList()) {
+      if (toEdge == fromEdge) continue;
+      if (lineCtd(fromEdge, toEdge, line)) {
+        return false;
+      }
+    }
+  }
+  return occurs;
+}
+
+// _____________________________________________________________________________
 double LineGraph::searchSpaceSize() const {
   double ret = 1;
 

--- a/src/shared/linegraph/LineGraph.h
+++ b/src/shared/linegraph/LineGraph.h
@@ -121,6 +121,8 @@ class LineGraph : public util::graph::UndirGraph<LineNodePL, LineEdgePL> {
   static bool terminatesAt(const LineEdge* fromEdge, const LineNode* terminus,
                            const Line* line);
 
+  static bool terminatesAt(const LineNode* n, const Line* line);
+
   static bool isTerminus(const LineNode* terminus);
 
   static std::vector<const Line*> getSharedLines(const LineEdge* a,

--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -905,9 +905,11 @@ void SvgRenderer::renderTerminusLabels(const RenderGraph &g,
   _w.openTag("g");
   for (auto n : g.getNds()) {
     std::set<const Line *> lines;
+    std::set<const Line *> seen;
     for (auto e : n->getAdjList()) {
       for (const auto &lo : e->pl().getLines()) {
-        if (RenderGraph::terminatesAt(e, n, lo.line)) {
+        if (seen.insert(lo.line).second &&
+            RenderGraph::terminatesAt(n, lo.line)) {
           lines.insert(lo.line);
         }
       }


### PR DESCRIPTION
## Summary
- Add node-aware `terminatesAt` helper to check if a line ends at a given node
- Use new helper when collecting terminus labels so only routes ending at the stop are labeled

## Testing
- `cmake ..` *(fails: source directory missing submodules)*
- `git submodule update --init --recursive` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e57bd748832da394a5aef1fd587a