### PR TITLE
Prevent collapsing reverse edges in topology builder

### DIFF
--- a/src/topo/mapconstructor/MapConstructor.cpp
+++ b/src/topo/mapconstructor/MapConstructor.cpp
@@ -46,6 +46,13 @@ bool MapConstructor::lineEq(const LineEdge* a, const LineEdge* b) {
   if (a->pl().getLines().size() != b->pl().getLines().size()) return false;
 
   const auto shrNd = LineGraph::sharedNode(a, b);
+  if (!shrNd) return false;
+
+  // If both edges connect the shared node to the same other node, they form
+  // a back-and-forth traversal over the exact same segment. In that case we
+  // must not collapse them into a single edge, otherwise both directions would
+  // be merged and could not be rendered separately.
+  if (a->getOtherNd(shrNd) == b->getOtherNd(shrNd)) return false;
 
   for (const auto& ra : a->pl().getLines()) {
     if (!b->pl().hasLine(ra.line)) return false;
@@ -57,7 +64,13 @@ bool MapConstructor::lineEq(const LineEdge* a, const LineEdge* b) {
     bool found = false;
 
     if (ra.direction == 0 && rb.direction == 0) {
-      found = true;
+      // Only treat the edges as equal if one enters the shared node and the
+      // other leaves it. This avoids collapsing parallel edges that simply
+      // connect to the same node.
+      if ((a->getTo() == shrNd && b->getFrom() == shrNd) ||
+          (a->getFrom() == shrNd && b->getTo() == shrNd)) {
+        found = true;
+      }
     }
     if (ra.direction == shrNd && rb.direction != 0 && rb.direction != shrNd) {
       found = true;

--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -558,8 +558,7 @@ void SvgRenderer::renderEdgeTripGeom(const RenderGraph &outG,
       oCss = lo.style.get().getOutlineCss();
     }
 
-    if (_cfg->renderDirMarkers && lo.direction != 0 &&
-        center.getLength() > arrowLength * 3) {
+    if (_cfg->renderDirMarkers && center.getLength() > arrowLength * 3) {
       std::stringstream markerName;
       markerName << e << ":" << line << ":" << i;
 
@@ -572,9 +571,29 @@ void SvgRenderer::renderEdgeTripGeom(const RenderGraph &outG,
       PolyLine<double> firstPart = p.getSegmentAtDist(0, p.getLength() / 2);
       PolyLine<double> secondPart =
           p.getSegmentAtDist(p.getLength() / 2, p.getLength());
+      PolyLine<double> revSecond = secondPart.reversed();
 
       double tailWorld = 15.0 / _cfg->outputResolution;
-      if (lo.direction == e->getTo()) {
+
+      if (lo.direction == 0) {
+        if (_cfg->renderMarkersTail) {
+          double tailStart =
+              std::max(0.0, firstPart.getLength() - tailWorld);
+          PolyLine<double> tail1 =
+              firstPart.getSegmentAtDist(tailStart, firstPart.getLength());
+          renderLinePart(tail1, lineW, *line, "stroke:black", "stroke:none");
+
+          tailStart = std::max(0.0, revSecond.getLength() - tailWorld);
+          PolyLine<double> tail2 =
+              revSecond.getSegmentAtDist(tailStart, revSecond.getLength());
+          renderLinePart(tail2, lineW, *line, "stroke:black", "stroke:none");
+        }
+
+        renderLinePart(firstPart, lineW, *line, css, oCss,
+                       markerName.str() + "_m");
+        renderLinePart(revSecond, lineW, *line, css, oCss,
+                       markerName.str() + "_m");
+      } else if (lo.direction == e->getTo()) {
         if (_cfg->renderMarkersTail) {
           double tailStart =
               std::max(0.0, firstPart.getLength() - tailWorld);
@@ -585,9 +604,8 @@ void SvgRenderer::renderEdgeTripGeom(const RenderGraph &outG,
         }
         renderLinePart(firstPart, lineW, *line, css, oCss,
                        markerName.str() + "_m");
-        renderLinePart(secondPart.reversed(), lineW, *line, css, oCss);
+        renderLinePart(revSecond, lineW, *line, css, oCss);
       } else {
-        PolyLine<double> revSecond = secondPart.reversed();
         if (_cfg->renderMarkersTail) {
           double tailStart =
               std::max(0.0, revSecond.getLength() - tailWorld);
@@ -595,7 +613,8 @@ void SvgRenderer::renderEdgeTripGeom(const RenderGraph &outG,
               revSecond.getSegmentAtDist(tailStart, revSecond.getLength());
           renderLinePart(tail, lineW, *line, "stroke:black", "stroke:none");
         }
-        renderLinePart(revSecond, lineW, *line, css, oCss, markerName.str() + "_m");
+        renderLinePart(revSecond, lineW, *line, css, oCss,
+                       markerName.str() + "_m");
         renderLinePart(firstPart, lineW, *line, css, oCss);
       }
     } else {


### PR DESCRIPTION
## Summary
- avoid merging edges representing back-and-forth segments so each direction can render separately
- render bidirectional markers with tails on both sides for segments used in both directions

## Testing
- `cmake ..` *(fails: The source directory `/workspace/loom/src/util` does not contain a CMakeLists.txt file)*

------
https://chatgpt.com/codex/tasks/task_e_68a6dff8b0bc832db8e800f246e2f88f