### PR TITLE
Fix terminus label assignment to match actual route endpoints

### DIFF
--- a/src/shared/linegraph/LineGraph.cpp
+++ b/src/shared/linegraph/LineGraph.cpp
@@ -1274,15 +1274,25 @@ bool LineGraph::isTerminus(const LineNode* nd) {
 // _____________________________________________________________________________
 bool LineGraph::terminatesAt(const LineEdge* fromEdge, const LineNode* terminus,
                              const Line* line) {
+  if (!fromEdge->pl().hasLine(line)) return false;
   for (const auto& toEdg : terminus->getAdjList()) {
     if (toEdg == fromEdge) continue;
-
-    if (lineCtd(fromEdge, toEdg, line)) {
+    if (toEdg->pl().hasLine(line)) {
       return false;
     }
   }
-
   return true;
+}
+
+// _____________________________________________________________________________
+bool LineGraph::terminatesAt(const LineNode* n, const Line* line) {
+  size_t count = 0;
+  for (auto e : n->getAdjList()) {
+    if (e->pl().hasLine(line) && ++count > 1) {
+      return false;
+    }
+  }
+  return count == 1;
 }
 
 // _____________________________________________________________________________

--- a/src/shared/linegraph/LineGraph.h
+++ b/src/shared/linegraph/LineGraph.h
@@ -121,6 +121,8 @@ class LineGraph : public util::graph::UndirGraph<LineNodePL, LineEdgePL> {
   static bool terminatesAt(const LineEdge* fromEdge, const LineNode* terminus,
                            const Line* line);
 
+  static bool terminatesAt(const LineNode* n, const Line* line);
+
   static bool isTerminus(const LineNode* terminus);
 
   static std::vector<const Line*> getSharedLines(const LineEdge* a,

--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -905,9 +905,11 @@ void SvgRenderer::renderTerminusLabels(const RenderGraph &g,
   _w.openTag("g");
   for (auto n : g.getNds()) {
     std::set<const Line *> lines;
+    std::set<const Line *> seen;
     for (auto e : n->getAdjList()) {
       for (const auto &lo : e->pl().getLines()) {
-        if (RenderGraph::terminatesAt(e, n, lo.line)) {
+        if (seen.insert(lo.line).second &&
+            RenderGraph::terminatesAt(n, lo.line)) {
           lines.insert(lo.line);
         }
       }


### PR DESCRIPTION
## Summary
- Simplify terminus detection to check for the presence of a line on multiple edges at a node
- Prevent labeling lines as terminating when they continue through a stop

## Testing
- `git submodule update --init --recursive` *(fails: CONNECT tunnel failed, response 403)*
- `mkdir -p build && cd build && cmake .. && cd ..` *(fails: missing CMakeLists.txt in submodules)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e57bd748832da394a5aef1fd587a