### PR TITLE
Measure station label width with FreeType

### DIFF
--- a/src/transitmap/CMakeLists.txt
+++ b/src/transitmap/CMakeLists.txt
@@ -6,8 +6,11 @@ list(REMOVE_ITEM transitmap_SRC ${transitmap_main})
 list(REMOVE_ITEM transitmap_SRC TestMain.cpp)
 
 include_directories(
-	${LOOM_INCLUDE_DIR}
+        ${LOOM_INCLUDE_DIR}
 )
+
+find_package(Freetype REQUIRED)
+include_directories(${FREETYPE_INCLUDE_DIRS})
 
 add_subdirectory(output/protobuf)
 add_subdirectory(tests)
@@ -19,6 +22,7 @@ configure_file (
 
 add_executable(transitmap ${transitmap_main})
 add_library(transitmap_dep ${transitmap_SRC})
+target_link_libraries(transitmap_dep PUBLIC ${FREETYPE_LIBRARIES})
 
 if (Protobuf_FOUND)
 	add_dependencies(transitmap_dep proto)

--- a/src/transitmap/label/Labeller.cpp
+++ b/src/transitmap/label/Labeller.cpp
@@ -6,6 +6,9 @@
 #include "transitmap/label/Labeller.h"
 #include "util/geo/Geo.h"
 #include <cmath>
+#include <string>
+#include <ft2build.h>
+#include FT_FREETYPE_H
 
 using shared::rendergraph::RenderGraph;
 using transitmapper::label::Labeller;
@@ -15,6 +18,39 @@ using transitmapper::label::StationLabel;
 
 using util::geo::MultiLine;
 using util::geo::PolyLine;
+
+namespace {
+double getTextWidthFT(const std::string& text, double fontSize,
+                      double resolution) {
+  static FT_Library library = nullptr;
+  static bool initialized = false;
+  if (!initialized) {
+    if (FT_Init_FreeType(&library)) {
+      return (text.size() + 1) * fontSize / 2.1;
+    }
+    initialized = true;
+  }
+
+  static const char* fontPath =
+      "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf";
+  FT_Face face;
+  if (FT_New_Face(library, fontPath, 0, &face)) {
+    return (text.size() + 1) * fontSize / 2.1;
+  }
+
+  FT_Set_Pixel_Sizes(
+      face, 0, static_cast<FT_UInt>(std::round(fontSize * resolution)));
+
+  double width = 0.0;
+  for (unsigned char c : text) {
+    if (FT_Load_Char(face, c, FT_LOAD_DEFAULT)) continue;
+    width += face->glyph->advance.x >> 6;
+  }
+
+  FT_Done_Face(face);
+  return width / resolution;
+}
+}  // namespace
 
 // _____________________________________________________________________________
 Labeller::Labeller(const config::Config* cfg) : _cfg(cfg) {}
@@ -34,10 +70,12 @@ util::geo::MultiLine<double> Labeller::getStationLblBand(
 
   double rad = util::geo::getEnclosingRadius(*n->pl().getGeom(), statHull);
 
-  // TODO: determine the label width based on the real font width. This is
-  // nontrivial, as it requires the fonts to be rendered for non-monospaced
-  // fonts
-  double labelW = (n->pl().stops().front().name.size() + 1) * fontSize / 2.1;
+  // measure the label width using FreeType
+  std::string lbl = n->pl().stops().front().name + " ";
+  double textWidth =
+      getTextWidthFT(lbl, fontSize, _cfg->outputResolution);
+  double offsetW = _cfg->lineSpacing + _cfg->lineWidth;
+  double labelW = offsetW + textWidth;
 
   util::geo::MultiLine<double> band;
 
@@ -45,21 +83,18 @@ util::geo::MultiLine<double> Labeller::getStationLblBand(
   double h = fontSize * 0.75;
 
   util::geo::Line<double> geomBaseLine, geomMiddle, geomTop, capLeft, capRight;
-  geomBaseLine.push_back(
-      {n->pl().getGeom()->getX() + rad + (_cfg->lineSpacing + _cfg->lineWidth),
-       n->pl().getGeom()->getY() - (offset * h / 2)});
+  geomBaseLine.push_back({n->pl().getGeom()->getX() + rad + offsetW,
+                          n->pl().getGeom()->getY() - (offset * h / 2)});
   geomBaseLine.push_back({n->pl().getGeom()->getX() + rad + labelW,
                           n->pl().getGeom()->getY() - (offset * h / 2)});
 
-  geomMiddle.push_back(
-      {n->pl().getGeom()->getX() + rad + (_cfg->lineSpacing + _cfg->lineWidth),
-       n->pl().getGeom()->getY() + h / 2 - (offset * h / 2)});
+  geomMiddle.push_back({n->pl().getGeom()->getX() + rad + offsetW,
+                        n->pl().getGeom()->getY() + h / 2 - (offset * h / 2)});
   geomMiddle.push_back({n->pl().getGeom()->getX() + rad + labelW,
                         n->pl().getGeom()->getY() + h / 2 - (offset * h / 2)});
 
-  geomTop.push_back(
-      {n->pl().getGeom()->getX() + rad + (_cfg->lineSpacing + _cfg->lineWidth),
-       n->pl().getGeom()->getY() + h - (offset * h / 2)});
+  geomTop.push_back({n->pl().getGeom()->getX() + rad + offsetW,
+                     n->pl().getGeom()->getY() + h - (offset * h / 2)});
   geomTop.push_back({n->pl().getGeom()->getX() + rad + labelW,
                      n->pl().getGeom()->getY() + h - (offset * h / 2)});
 


### PR DESCRIPTION
## Summary
- compute station label text width using FreeType instead of a heuristic
- recompute label bands based on measured width
- link the transitmap target against FreeType

## Testing
- `cmake -S . -B build` *(fails: source directory src/util missing)*
- `cmake --build build_transitmap` *(fails: shared/rendergraph/Penalties.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f778eb80832d928a7e514822268a