### PR TITLE
Measure station label width with FreeType

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,31 @@ Requirements
  * `cmake`
  * `gcc >= 5.0` (or `clang >= 3.9`)
  * Optional: `libglpk-dev`, `coinor-libcbc-dev`, `gurobi`, `libzip-dev`, `libprotobuf-dev`
+ * Optional: `freetype2` (libfreetype) for accurate label rendering
+
+
+Installing FreeType
+-------------------
+
+The map renderer uses the FreeType font engine to measure label text. Install the development package for your platform:
+
+### Debian/Ubuntu
+
+```bash
+sudo apt-get install libfreetype6-dev
+```
+
+### macOS (Homebrew)
+
+```bash
+brew install freetype
+```
+
+### Windows (vcpkg)
+
+```powershell
+vcpkg install freetype
+```
 
 
 Building and Installation

--- a/src/transitmap/CMakeLists.txt
+++ b/src/transitmap/CMakeLists.txt
@@ -6,8 +6,13 @@ list(REMOVE_ITEM transitmap_SRC ${transitmap_main})
 list(REMOVE_ITEM transitmap_SRC TestMain.cpp)
 
 include_directories(
-	${LOOM_INCLUDE_DIR}
+        ${LOOM_INCLUDE_DIR}
 )
+
+find_package(Freetype)
+if (FREETYPE_FOUND)
+  include_directories(${FREETYPE_INCLUDE_DIRS})
+endif()
 
 add_subdirectory(output/protobuf)
 add_subdirectory(tests)
@@ -19,6 +24,10 @@ configure_file (
 
 add_executable(transitmap ${transitmap_main})
 add_library(transitmap_dep ${transitmap_SRC})
+if (FREETYPE_FOUND)
+  target_link_libraries(transitmap_dep PUBLIC ${FREETYPE_LIBRARIES})
+  target_compile_definitions(transitmap_dep PUBLIC LOOM_HAVE_FREETYPE)
+endif()
 
 if (Protobuf_FOUND)
 	add_dependencies(transitmap_dep proto)

--- a/src/transitmap/label/Labeller.cpp
+++ b/src/transitmap/label/Labeller.cpp
@@ -6,6 +6,11 @@
 #include "transitmap/label/Labeller.h"
 #include "util/geo/Geo.h"
 #include <cmath>
+#include <string>
+#ifdef LOOM_HAVE_FREETYPE
+#include <ft2build.h>
+#include FT_FREETYPE_H
+#endif
 
 using shared::rendergraph::RenderGraph;
 using transitmapper::label::Labeller;
@@ -15,6 +20,44 @@ using transitmapper::label::StationLabel;
 
 using util::geo::MultiLine;
 using util::geo::PolyLine;
+
+namespace {
+double getTextWidthFT(const std::string& text, double fontSize,
+                      double resolution) {
+#ifdef LOOM_HAVE_FREETYPE
+  static FT_Library library = nullptr;
+  static bool initialized = false;
+  if (!initialized) {
+    if (FT_Init_FreeType(&library)) {
+      return (text.size() + 1) * fontSize / 2.1;
+    }
+    initialized = true;
+  }
+
+  static const char* fontPath =
+      "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf";
+  FT_Face face;
+  if (FT_New_Face(library, fontPath, 0, &face)) {
+    return (text.size() + 1) * fontSize / 2.1;
+  }
+
+  FT_Set_Pixel_Sizes(
+      face, 0, static_cast<FT_UInt>(std::round(fontSize * resolution)));
+
+  double width = 0.0;
+  for (unsigned char c : text) {
+    if (FT_Load_Char(face, c, FT_LOAD_DEFAULT)) continue;
+    width += face->glyph->advance.x >> 6;
+  }
+
+  FT_Done_Face(face);
+  return width / resolution;
+#else
+  (void)resolution;
+  return (text.size() + 1) * fontSize / 2.1;
+#endif
+}
+}  // namespace
 
 // _____________________________________________________________________________
 Labeller::Labeller(const config::Config* cfg) : _cfg(cfg) {}
@@ -34,10 +77,12 @@ util::geo::MultiLine<double> Labeller::getStationLblBand(
 
   double rad = util::geo::getEnclosingRadius(*n->pl().getGeom(), statHull);
 
-  // TODO: determine the label width based on the real font width. This is
-  // nontrivial, as it requires the fonts to be rendered for non-monospaced
-  // fonts
-  double labelW = (n->pl().stops().front().name.size() + 1) * fontSize / 2.1;
+  // measure the label width using FreeType
+  std::string lbl = n->pl().stops().front().name + " ";
+  double textWidth =
+      getTextWidthFT(lbl, fontSize, _cfg->outputResolution);
+  double offsetW = _cfg->lineSpacing + _cfg->lineWidth;
+  double labelW = offsetW + textWidth;
 
   util::geo::MultiLine<double> band;
 
@@ -45,21 +90,18 @@ util::geo::MultiLine<double> Labeller::getStationLblBand(
   double h = fontSize * 0.75;
 
   util::geo::Line<double> geomBaseLine, geomMiddle, geomTop, capLeft, capRight;
-  geomBaseLine.push_back(
-      {n->pl().getGeom()->getX() + rad + (_cfg->lineSpacing + _cfg->lineWidth),
-       n->pl().getGeom()->getY() - (offset * h / 2)});
+  geomBaseLine.push_back({n->pl().getGeom()->getX() + rad + offsetW,
+                          n->pl().getGeom()->getY() - (offset * h / 2)});
   geomBaseLine.push_back({n->pl().getGeom()->getX() + rad + labelW,
                           n->pl().getGeom()->getY() - (offset * h / 2)});
 
-  geomMiddle.push_back(
-      {n->pl().getGeom()->getX() + rad + (_cfg->lineSpacing + _cfg->lineWidth),
-       n->pl().getGeom()->getY() + h / 2 - (offset * h / 2)});
+  geomMiddle.push_back({n->pl().getGeom()->getX() + rad + offsetW,
+                        n->pl().getGeom()->getY() + h / 2 - (offset * h / 2)});
   geomMiddle.push_back({n->pl().getGeom()->getX() + rad + labelW,
                         n->pl().getGeom()->getY() + h / 2 - (offset * h / 2)});
 
-  geomTop.push_back(
-      {n->pl().getGeom()->getX() + rad + (_cfg->lineSpacing + _cfg->lineWidth),
-       n->pl().getGeom()->getY() + h - (offset * h / 2)});
+  geomTop.push_back({n->pl().getGeom()->getX() + rad + offsetW,
+                     n->pl().getGeom()->getY() + h - (offset * h / 2)});
   geomTop.push_back({n->pl().getGeom()->getX() + rad + labelW,
                      n->pl().getGeom()->getY() + h - (offset * h / 2)});
 


### PR DESCRIPTION
## Summary
- compute station label text width with FreeType when available, falling back to heuristic sizing otherwise
- make the transitmap build link against FreeType only if found and define `LOOM_HAVE_FREETYPE`

## Testing
- `cmake -S . -B build` *(fails: source directory src/util missing)*
- `cmake -S src/transitmap -B build_transitmap`
- `cmake --build build_transitmap` *(fails: shared/rendergraph/Penalties.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f778eb80832d928a7e514822268a