### PR TITLE
Add landmark configuration to TransitMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,13 @@ A full pipeline for creating an octilinear map of the Freiburg tram network woul
 gtfs2graph -m tram freiburg.zip | topo | loom | octi | transitmap > freiburg-tram.svg
 ```
 
+A sample landmarks file with matching SVG icons is provided in
+`examples/landmarks.txt`. To render these landmarks alongside a map, run
+
+```
+cat examples/stuttgart.json | loom | transitmap --landmarks examples/landmarks.txt > stuttgart-landmarks.svg
+```
+
 Usage via Docker
 ================
 

--- a/examples/icons/landmark1.svg
+++ b/examples/icons/landmark1.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="40" fill="#e6194B" />
+</svg>

--- a/examples/icons/landmark10.svg
+++ b/examples/icons/landmark10.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="40" fill="#fabebe" />
+</svg>

--- a/examples/icons/landmark2.svg
+++ b/examples/icons/landmark2.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="40" fill="#3cb44b" />
+</svg>

--- a/examples/icons/landmark3.svg
+++ b/examples/icons/landmark3.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="40" fill="#ffe119" />
+</svg>

--- a/examples/icons/landmark4.svg
+++ b/examples/icons/landmark4.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="40" fill="#0082c8" />
+</svg>

--- a/examples/icons/landmark5.svg
+++ b/examples/icons/landmark5.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="40" fill="#f58231" />
+</svg>

--- a/examples/icons/landmark6.svg
+++ b/examples/icons/landmark6.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="40" fill="#911eb4" />
+</svg>

--- a/examples/icons/landmark7.svg
+++ b/examples/icons/landmark7.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="40" fill="#46f0f0" />
+</svg>

--- a/examples/icons/landmark8.svg
+++ b/examples/icons/landmark8.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="40" fill="#f032e6" />
+</svg>

--- a/examples/icons/landmark9.svg
+++ b/examples/icons/landmark9.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="40" fill="#d2f53c" />
+</svg>

--- a/examples/landmarks.txt
+++ b/examples/landmarks.txt
@@ -1,0 +1,10 @@
+examples/icons/landmark1.svg,52.5200,13.4050,40
+examples/icons/landmark2.svg,48.8566,2.3522,40
+examples/icons/landmark3.svg,51.5074,-0.1278,40
+examples/icons/landmark4.svg,40.7128,-74.0060,40
+examples/icons/landmark5.svg,34.0522,-118.2437,40
+examples/icons/landmark6.svg,35.6895,139.6917,40
+examples/icons/landmark7.svg,55.7558,37.6173,40
+examples/icons/landmark8.svg,39.9042,116.4074,40
+examples/icons/landmark9.svg,-33.8688,151.2093,40
+examples/icons/landmark10.svg,37.7749,-122.4194,40

--- a/src/transitmap/config/ConfigReader.cpp
+++ b/src/transitmap/config/ConfigReader.cpp
@@ -6,6 +6,7 @@
 #include <getopt.h>
 
 #include <exception>
+#include <fstream>
 #include <iostream>
 #include <string>
 
@@ -13,9 +14,11 @@
 #include "transitmap/config/ConfigReader.h"
 #include "util/String.h"
 #include "util/log/Log.h"
+#include "util/geo/Geo.h"
 
 using std::exception;
 using transitmapper::config::ConfigReader;
+using transitmapper::config::Landmark;
 
 static const char *YEAR = &__DATE__[7];
 static const char *COPY =
@@ -85,10 +88,14 @@ void ConfigReader::help(const char *bin) const {
             << "don't render stations\n"
             << std::setw(37) << "  --no-render-node-connections"
             << "don't render inner node connections\n"
-            << std::setw(37) << "  --render-node-fronts"
-            << "render node fronts\n"
-            << std::setw(37) << "  --print-stats"
-            << "write stats to stdout\n";
+            << std::setw(37) << "  --render-node-fronts" 
+            << "render node fronts\n" 
+            << std::setw(37) << "  --landmark arg" 
+            << "add landmark lat,lon or iconPath,lat,lon,size\n" 
+            << std::setw(37) << "  --landmarks arg" 
+            << "read landmarks from file, one iconPath,lat,lon,size per line\n" 
+            << std::setw(37) << "  --print-stats" 
+            << "write stats to stdout\n"; 
 }
 
 // _____________________________________________________________________________
@@ -118,6 +125,8 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
                          {"mvt-path", required_argument, 0, 17},
                          {"random-colors", no_argument, 0, 18},
                          {"print-stats", no_argument, 0, 19},
+                         {"landmark", required_argument, 0, 21},
+                         {"landmarks", required_argument, 0, 22},
                          {0, 0, 0, 0}};
 
   std::string zoom;
@@ -194,6 +203,57 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
     case 19:
       cfg->writeStats = true;
       break;
+    case 21: {
+      auto parts = util::split(optarg, ',');
+      Landmark lm;
+
+      if (parts.size() == 2) {
+        double lat = atof(parts[0].c_str());
+        double lon = atof(parts[1].c_str());
+        lm.coord = util::geo::latLngToWebMerc<double>(lat, lon);
+      } else if (parts.size() == 4) {
+        lm.iconPath = parts[0];
+        double lat = atof(parts[1].c_str());
+        double lon = atof(parts[2].c_str());
+        lm.size = atof(parts[3].c_str());
+        lm.coord = util::geo::latLngToWebMerc<double>(lat, lon);
+      } else {
+        std::cerr << "Error while parsing landmark " << optarg << std::endl;
+        exit(1);
+      }
+
+      cfg->landmarks.push_back(lm);
+      break;
+    }
+    case 22: {
+      std::ifstream infile(optarg);
+      if (!infile.good()) {
+        std::cerr << "Could not open landmarks file " << optarg << std::endl;
+        exit(1);
+      }
+      std::string line;
+      while (std::getline(infile, line)) {
+        if (line.empty()) continue;
+        auto parts = util::split(line, ',');
+        Landmark lm;
+        if (parts.size() == 2) {
+          double lat = atof(parts[0].c_str());
+          double lon = atof(parts[1].c_str());
+          lm.coord = util::geo::latLngToWebMerc<double>(lat, lon);
+        } else if (parts.size() == 4) {
+          lm.iconPath = parts[0];
+          double lat = atof(parts[1].c_str());
+          double lon = atof(parts[2].c_str());
+          lm.size = atof(parts[3].c_str());
+          lm.coord = util::geo::latLngToWebMerc<double>(lat, lon);
+        } else {
+          std::cerr << "Error while parsing landmark " << line << std::endl;
+          exit(1);
+        }
+        cfg->landmarks.push_back(lm);
+      }
+      break;
+    }
     case 'D':
       cfg->fromDot = true;
       break;

--- a/src/transitmap/config/TransitMapConfig.h
+++ b/src/transitmap/config/TransitMapConfig.h
@@ -6,9 +6,17 @@
 #define TRANSITMAP_CONFIG_TRANSITMAPCONFIG_H_
 
 #include <string>
+#include <vector>
+#include "util/geo/Geo.h"
 
 namespace transitmapper {
 namespace config {
+
+struct Landmark {
+  std::string iconPath;
+  util::geo::DPoint coord;
+  double size = 0;
+};
 
 struct Config {
   double lineWidth = 20;
@@ -51,6 +59,8 @@ struct Config {
   bool renderDirMarkers = false;
   bool renderMarkersTail = false;
   std::string worldFilePath;
+
+  std::vector<Landmark> landmarks;
 };
 
 } // namespace config


### PR DESCRIPTION
## Summary
- support landmark definitions with icon path and optional size
- parse landmark CLI options converting lat/lon to Web-Mercator coordinates
- allow loading multiple landmarks from a file via `--landmarks`
- provide sample landmarks and SVG icons for testing

## Testing
- `cmake ..` *(fails: source directories missing `CMakeLists.txt`)*
- `cmake --build .` *(fails: No rule to make target 'Makefile')*


------
https://chatgpt.com/codex/tasks/task_e_68a80b8bde6c832dbe1c562c61984f04