### PR TITLE
feat: render landmarks in SVG output

### DIFF
--- a/src/transitmap/output/SvgRenderer.h
+++ b/src/transitmap/output/SvgRenderer.h
@@ -100,6 +100,9 @@ class SvgRenderer : public Renderer {
   void renderNodeFronts(const shared::rendergraph::RenderGraph& outG,
                         const RenderParams& params);
 
+  void renderLandmarks(const shared::rendergraph::RenderGraph& g,
+                       const RenderParams& params);
+
   void renderLineLabels(const label::Labeller& lbler,
                         const RenderParams& params);
 


### PR DESCRIPTION
## Summary
- add renderLandmarks to SvgRenderer to output icon defs and placement
- invoke renderLandmarks after nodes are rendered and before label rendering

## Testing
- `cmake ..` (fails: The source directory `/workspace/loom/src/util` does not contain a CMakeLists.txt file.)

------
https://chatgpt.com/codex/tasks/task_e_68a80cddc9f4832d818f1748e75c4d05