### PR TITLE
Add landmark collision index to label placement

### DIFF
--- a/src/transitmap/label/Labeller.cpp
+++ b/src/transitmap/label/Labeller.cpp
@@ -5,6 +5,7 @@
 #include "shared/rendergraph/RenderGraph.h"
 #include "transitmap/label/Labeller.h"
 #include "util/geo/Geo.h"
+#include <set>
 #include <cmath>
 #include <string>
 #include <ft2build.h>
@@ -362,4 +363,26 @@ util::geo::Box<double> Labeller::getBBox() const {
   for (auto lbl : _stationLabels) ret = util::geo::extendBox(lbl.band, ret);
 
   return ret;
+}
+
+// _____________________________________________________________________________
+bool Labeller::collidesWithLabels(const util::geo::Box<double>& box) const {
+  std::set<size_t> overlaps;
+  _landmarkIdx.get(box, 0, &overlaps);
+  if (!overlaps.empty()) return true;
+  _statLblIdx.get(box, 0, &overlaps);
+  return !overlaps.empty();
+}
+
+// _____________________________________________________________________________
+bool Labeller::addLandmark(const util::geo::Box<double>& box) {
+  if (collidesWithLabels(box)) return false;
+  _landmarkIdx.add(box, _landmarks.size());
+  _landmarks.push_back(box);
+  return true;
+}
+
+// _____________________________________________________________________________
+const std::vector<util::geo::Box<double>>& Labeller::getLandmarks() const {
+  return _landmarks;
 }

--- a/src/transitmap/label/Labeller.h
+++ b/src/transitmap/label/Labeller.h
@@ -9,6 +9,7 @@
 #include "shared/rendergraph/RenderGraph.h"
 #include "transitmap/config/TransitMapConfig.h"
 #include "util/geo/Grid.h"
+#include "util/geo/Box.h"
 #include "util/geo/RTree.h"
 
 namespace transitmapper {
@@ -101,6 +102,7 @@ inline bool operator<(const StationLabel& a, const StationLabel& b) {
 // typedef util::geo::Grid<size_t, util::geo::Line, double> LineLblIdx;
 typedef util::geo::RTree<size_t, util::geo::MultiLine, double> StatLblIdx;
 typedef util::geo::RTree<size_t, util::geo::Line, double> LineLblIdx;
+typedef util::geo::RTree<size_t, util::geo::Box, double> LandmarkIdx;
 
 class Labeller {
  public:
@@ -111,11 +113,20 @@ class Labeller {
   const std::vector<LineLabel>& getLineLabels() const;
   const std::vector<StationLabel>& getStationLabels() const;
 
+  // Add and query landmark icons.
+  bool addLandmark(const util::geo::Box<double>& box);
+  bool collidesWithLabels(const util::geo::Box<double>& box) const;
+  const std::vector<util::geo::Box<double>>& getLandmarks() const;
+
   util::geo::Box<double> getBBox() const;
 
  private:
   std::vector<LineLabel> _lineLabels;
   std::vector<StationLabel> _stationLabels;
+
+  // index of placed landmark bounding boxes
+  LandmarkIdx _landmarkIdx;
+  std::vector<util::geo::Box<double>> _landmarks;
 
   StatLblIdx _statLblIdx;
 


### PR DESCRIPTION
## Summary
- track landmark icon bounding boxes via a new `LandmarkIdx` R-tree
- provide helpers to insert landmarks and detect overlaps with existing station labels

## Testing
- `cmake .. && make test` *(fails: source directory /workspace/loom/src/util does not contain a CMakeLists.txt file)*

------
https://chatgpt.com/codex/tasks/task_e_68a80cdc1c44832db361c80457363617