### PR TITLE
Add side-specific padding options to transitmap renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,13 @@ To render for example the orthoradial map from above, use a different base graph
 cat examples/stuttgart.json | loom | octi -b orthoradial | transitmap -l > stuttgart-orthorad.svg
 ```
 
+Padding can now be specified per side. For example, to add padding only to the
+top and left of the map:
+
+```
+cat examples/stuttgart.json | loom | transitmap --padding 0 --padding-top 50 --padding-left 20 > stuttgart-pad.svg
+```
+
 Tool capabilities
 -----------------
 
@@ -199,6 +206,10 @@ Command-line parameters
 * `--zoom <levels>` and `--mvt-path <dir>`: zoom levels and output path for MVT tiles.
 * `-D`, `--from-dot`: input graph is in DOT format.
 * `--padding <padding>`: padding around the map (`-1` for auto).
+* `--padding-top <padding>`: padding at the top of the map (`-1` for auto).
+* `--padding-right <padding>`: padding at the right side (`-1` for auto).
+* `--padding-bottom <padding>`: padding at the bottom (`-1` for auto).
+* `--padding-left <padding>`: padding at the left side (`-1` for auto).
 * `--smoothing <factor>`: input line smoothing (default `1`).
 * `--random-colors`: fill missing colors with random colors.
 * `--tight-stations`: don't expand node fronts for stations.

--- a/src/transitmap/config/ConfigReader.cpp
+++ b/src/transitmap/config/ConfigReader.cpp
@@ -78,6 +78,14 @@ void ConfigReader::help(const char *bin) const {
             << "input is in dot format\n"
             << std::setw(37) << "  --padding arg (=-1)"
             << "padding, -1 for auto\n"
+            << std::setw(37) << "  --padding-top arg (=-1)"
+            << "top padding, -1 for auto\n"
+            << std::setw(37) << "  --padding-right arg (=-1)"
+            << "right padding, -1 for auto\n"
+            << std::setw(37) << "  --padding-bottom arg (=-1)"
+            << "bottom padding, -1 for auto\n"
+            << std::setw(37) << "  --padding-left arg (=-1)"
+            << "left padding, -1 for auto\n"
             << std::setw(37) << "  --smoothing arg (=1)"
             << "input line smoothing\n"
             << std::setw(37) << "  --random-colors"
@@ -119,6 +127,10 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
                          {"no-render-node-connections", no_argument, 0, 11},
                          {"resolution", required_argument, 0, 12},
                          {"padding", required_argument, 0, 13},
+                         {"padding-top", required_argument, 0, 23},
+                         {"padding-right", required_argument, 0, 24},
+                         {"padding-bottom", required_argument, 0, 25},
+                         {"padding-left", required_argument, 0, 26},
                          {"smoothing", required_argument, 0, 14},
                          {"render-node-fronts", no_argument, 0, 15},
                          {"zoom", required_argument, 0, 'z'},
@@ -184,6 +196,18 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
       break;
     case 13:
       cfg->outputPadding = atof(optarg);
+      break;
+    case 23:
+      cfg->paddingTop = atof(optarg);
+      break;
+    case 24:
+      cfg->paddingRight = atof(optarg);
+      break;
+    case 25:
+      cfg->paddingBottom = atof(optarg);
+      break;
+    case 26:
+      cfg->paddingLeft = atof(optarg);
       break;
     case 14:
       cfg->inputSmoothing = atof(optarg);
@@ -322,4 +346,8 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
   if (cfg->outputPadding < 0) {
     cfg->outputPadding = (cfg->lineWidth + cfg->lineSpacing);
   }
+  if (cfg->paddingTop < 0) cfg->paddingTop = cfg->outputPadding;
+  if (cfg->paddingRight < 0) cfg->paddingRight = cfg->outputPadding;
+  if (cfg->paddingBottom < 0) cfg->paddingBottom = cfg->outputPadding;
+  if (cfg->paddingLeft < 0) cfg->paddingLeft = cfg->outputPadding;
 }

--- a/src/transitmap/config/TransitMapConfig.h
+++ b/src/transitmap/config/TransitMapConfig.h
@@ -36,6 +36,10 @@ struct Config {
   double innerGeometryPrecision = 3;
 
   double outputPadding = -1;
+  double paddingTop = -1;
+  double paddingRight = -1;
+  double paddingBottom = -1;
+  double paddingLeft = -1;
 
   double outlineWidth = 1;
   std::string outlineColor;

--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -55,9 +55,11 @@ void SvgRenderer::print(const RenderGraph &outG) {
     box = util::geo::extendBox(labeller.getBBox(), box);
   }
 
-  double p = _cfg->outputPadding;
-
-  box = util::geo::pad(box, p);
+  DPoint ll(box.getLowerLeft().getX() - _cfg->paddingLeft,
+            box.getLowerLeft().getY() - _cfg->paddingBottom);
+  DPoint ur(box.getUpperRight().getX() + _cfg->paddingRight,
+            box.getUpperRight().getY() + _cfg->paddingTop);
+  box = util::geo::Box<double>(ll, ur);
 
   if (!_cfg->worldFilePath.empty()) {
     std::ofstream file;


### PR DESCRIPTION
## Summary
- Support `paddingTop`, `paddingRight`, `paddingBottom`, and `paddingLeft` in transit map configuration
- Parse new `--padding-*` CLI flags and apply per-side padding in SVG renderer
- Document per-side padding usage and examples in README

## Testing
- `cmake ..` *(fails: source directory `/workspace/loom/src/util` does not contain a CMakeLists.txt file)*

------
https://chatgpt.com/codex/tasks/task_e_68a814172ea0832d9b3c36e0abe3d9d7