### PR TITLE
Use TT Norms Pro font

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Requirements
 Installing FreeType
 -------------------
 
-The map renderer uses the FreeType font engine to measure label text. Install the development package for your platform:
+The map renderer uses the FreeType font engine to measure label text and the TT Norms Pro font bundled under `data/fonts` for rendering. Install the development package for your platform:
 
 ### Debian/Ubuntu
 

--- a/src/transitmap/label/Labeller.cpp
+++ b/src/transitmap/label/Labeller.cpp
@@ -59,7 +59,7 @@ double getTextWidthFT(const std::string& text, double fontSize,
   }
 
   static const char* fontPath =
-      "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf";
+      "data/fonts/TT Norms Pro Regular.otf";
   FT_Face face;
   if (FT_New_Face(library, fontPath, 0, &face)) {
     return (text.size() + 1) * fontSize / 2.1;

--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -856,7 +856,7 @@ void SvgRenderer::renderStationLabels(const Labeller &labeller,
     std::map<std::string, std::string> params;
     params["class"] = "station-label";
     params["font-weight"] = label.bold ? "bold" : "normal";
-    params["font-family"] = "Ubuntu Condensed";
+    params["font-family"] = "TT Norms Pro";
     params["dy"] = shift;
     params["font-size"] =
         util::toString(label.fontSize * _cfg->outputResolution);
@@ -919,7 +919,7 @@ void SvgRenderer::renderLineLabels(const Labeller &labeller,
     std::map<std::string, std::string> params;
     params["class"] = "line-label";
     params["font-weight"] = "bold";
-    params["font-family"] = "Ubuntu";
+    params["font-family"] = "TT Norms Pro";
     params["dy"] = shift;
     params["font-size"] =
         util::toString(label.fontSize * _cfg->outputResolution);
@@ -1051,7 +1051,7 @@ void SvgRenderer::renderTerminusLabels(const RenderGraph &g,
 
       _w.openTag("text", {{"class", "line-label"},
                           {"font-weight", "bold"},
-                          {"font-family", "Ubuntu"},
+                          {"font-family", "TT Norms Pro"},
                           {"text-anchor", "middle"},
                           {"dominant-baseline", "middle"},
                           {"alignment-baseline", "middle"},


### PR DESCRIPTION
## Summary
- Replace Ubuntu font references with TT Norms Pro for SVG rendering
- Measure text using bundled TT Norms Pro font file
- Document use of TT Norms Pro fonts

## Testing
- `cmake -S . -B build` *(fails: The source directory /workspace/loom/src/util does not contain a CMakeLists.txt file.)*

------
https://chatgpt.com/codex/tasks/task_e_68a81ad3a554832da952948c61a7d098