### PR TITLE
feat: add aspect ratio option for transitmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Command-line parameters
 * `--padding-bottom <padding>`: padding at the bottom (`-1` for auto).
 * `--padding-left <padding>`: padding at the left side (`-1` for auto).
 * `--smoothing <factor>`: input line smoothing (default `1`).
+* `--ratio <value>`: output width/height ratio (`width = height * ratio`).
 * `--random-colors`: fill missing colors with random colors.
 * `--tight-stations`: don't expand node fronts for stations.
 * `--no-render-stations`: don't render stations.

--- a/src/transitmap/config/ConfigReader.cpp
+++ b/src/transitmap/config/ConfigReader.cpp
@@ -88,6 +88,8 @@ void ConfigReader::help(const char *bin) const {
             << "left padding, -1 for auto\n"
             << std::setw(37) << "  --smoothing arg (=1)"
             << "input line smoothing\n"
+            << std::setw(37) << "  --ratio arg (=-1)"
+            << "output width/height ratio\n"
             << std::setw(37) << "  --random-colors"
             << "fill missing colors with random colors\n"
             << std::setw(37) << "  --tight-stations"
@@ -132,6 +134,7 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
                          {"padding-bottom", required_argument, 0, 25},
                          {"padding-left", required_argument, 0, 26},
                          {"smoothing", required_argument, 0, 14},
+                         {"ratio", required_argument, 0, 27},
                          {"render-node-fronts", no_argument, 0, 15},
                          {"zoom", required_argument, 0, 'z'},
                          {"mvt-path", required_argument, 0, 17},
@@ -211,6 +214,9 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
       break;
     case 14:
       cfg->inputSmoothing = atof(optarg);
+      break;
+    case 27:
+      cfg->ratio = atof(optarg);
       break;
     case 15:
       cfg->renderNodeFronts = true;
@@ -350,4 +356,9 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
   if (cfg->paddingRight < 0) cfg->paddingRight = cfg->outputPadding;
   if (cfg->paddingBottom < 0) cfg->paddingBottom = cfg->outputPadding;
   if (cfg->paddingLeft < 0) cfg->paddingLeft = cfg->outputPadding;
+
+  if (cfg->ratio != -1 && cfg->ratio <= 0) {
+    std::cerr << "Error: ratio " << cfg->ratio << " is not positive!" << std::endl;
+    exit(1);
+  }
 }

--- a/src/transitmap/config/TransitMapConfig.h
+++ b/src/transitmap/config/TransitMapConfig.h
@@ -41,6 +41,8 @@ struct Config {
   double paddingBottom = -1;
   double paddingLeft = -1;
 
+  double ratio = -1;
+
   double outlineWidth = 1;
   std::string outlineColor;
 

--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -69,6 +69,24 @@ void SvgRenderer::print(const RenderGraph &outG) {
             box.getUpperRight().getY() + _cfg->paddingTop);
   box = util::geo::Box<double>(ll, ur);
 
+  if (_cfg->ratio > 0) {
+    double curWidth = box.getUpperRight().getX() - box.getLowerLeft().getX();
+    double curHeight = box.getUpperRight().getY() - box.getLowerLeft().getY();
+    double desiredWidth = curHeight * _cfg->ratio;
+    if (desiredWidth > curWidth) {
+      double pad = (desiredWidth - curWidth) / 2.0;
+      DPoint nll(box.getLowerLeft().getX() - pad, box.getLowerLeft().getY());
+      DPoint nur(box.getUpperRight().getX() + pad, box.getUpperRight().getY());
+      box = util::geo::Box<double>(nll, nur);
+    } else if (desiredWidth < curWidth) {
+      double desiredHeight = curWidth / _cfg->ratio;
+      double pad = (desiredHeight - curHeight) / 2.0;
+      DPoint nll(box.getLowerLeft().getX(), box.getLowerLeft().getY() - pad);
+      DPoint nur(box.getUpperRight().getX(), box.getUpperRight().getY() + pad);
+      box = util::geo::Box<double>(nll, nur);
+    }
+  }
+
   if (!_cfg->worldFilePath.empty()) {
     std::ofstream file;
     file.open(_cfg->worldFilePath);


### PR DESCRIPTION
## Summary
- allow setting a custom aspect ratio for SVG output via `--ratio`
- parse and validate new `--ratio` flag
- document ratio option in README

## Testing
- `cmake -S . -B build` *(fails: missing submodules)*
- `git submodule update --init --recursive` *(fails: unable to access submodule URLs)*

------
https://chatgpt.com/codex/tasks/task_e_68a823ac115c832dbb892db0b3f15202