### PR TITLE
Render shared tail for bidirectional direction markers

### DIFF
--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -644,8 +644,7 @@ void SvgRenderer::renderEdgeTripGeom(const RenderGraph &outG,
       oCss = lo.style.get().getOutlineCss();
     }
 
-    if (_cfg->renderDirMarkers && lo.direction != 0 &&
-        center.getLength() > arrowLength * 3) {
+    if (_cfg->renderDirMarkers && center.getLength() > arrowLength * 3) {
       std::stringstream markerName;
       markerName << e << ":" << line << ":" << i;
 
@@ -660,7 +659,17 @@ void SvgRenderer::renderEdgeTripGeom(const RenderGraph &outG,
           p.getSegmentAtDist(p.getLength() / 2, p.getLength());
 
       double tailWorld = 15.0 / _cfg->outputResolution;
-      if (lo.direction == e->getTo()) {
+      if (lo.direction == 0) {
+        if (_cfg->renderMarkersTail) {
+          PolyLine<double> tail = p.getSegmentAtDist(
+              p.getLength() / 2 - tailWorld, p.getLength() / 2 + tailWorld);
+          renderLinePart(tail, lineW, *line, "stroke:black", "stroke:none");
+        }
+        renderLinePart(firstPart, lineW, *line, css, oCss,
+                       markerName.str() + "_m");
+        renderLinePart(secondPart.reversed(), lineW, *line, css, oCss,
+                       markerName.str() + "_m");
+      } else if (lo.direction == e->getTo()) {
         if (_cfg->renderMarkersTail) {
           double tailStart =
               std::max(0.0, firstPart.getLength() - tailWorld);


### PR DESCRIPTION
## Summary
- Render line marker tails once for bidirectional edges.
- Split path halves and apply direction markers to each half without duplicate tails.

## Testing
- `cmake ..` *(fails: src/util missing CMakeLists due to unavailable submodules)*
- `git submodule update --init --recursive` *(fails: CONNECT tunnel failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68aad7f1c284832d8cc4ce66f25663b4