### PR TITLE
Split bidirectional marker tail

### DIFF
--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -657,11 +657,28 @@ void SvgRenderer::renderEdgeTripGeom(const RenderGraph &outG,
           p.getSegmentAtDist(p.getLength() / 2, p.getLength());
       PolyLine<double> revSecond = secondPart.reversed();
 
-      double tailWorld = 15.0 / _cfg->outputResolution;
       if (lo.direction == 0) {
-        renderLinePart(p, lineW, *line, css, oCss, markerName.str() + "_m",
+        double mid = p.getLength() / 2;
+        double tailWorld = 15.0 / _cfg->outputResolution;
+        double tailStart = mid - tailWorld / 2;
+        double tailEnd = mid + tailWorld / 2;
+
+        if (_cfg->renderMarkersTail) {
+          PolyLine<double> tail = p.getSegmentAtDist(tailStart, tailEnd);
+          renderLinePart(tail, lineW, *line, "stroke:black", "stroke:none");
+        }
+
+        PolyLine<double> firstHalf = p.getSegmentAtDist(0, tailStart);
+        PolyLine<double> secondHalf =
+            p.getSegmentAtDist(tailEnd, p.getLength());
+        PolyLine<double> revFirstHalf = firstHalf.reversed();
+
+        renderLinePart(revFirstHalf, lineW, *line, css, oCss,
+                       markerName.str() + "_m");
+        renderLinePart(secondHalf, lineW, *line, css, oCss,
                        markerName.str() + "_m");
       } else if (lo.direction == e->getTo()) {
+        double tailWorld = 15.0 / _cfg->outputResolution;
         if (_cfg->renderMarkersTail) {
           double tailStart = std::max(0.0, firstPart.getLength() - tailWorld);
           PolyLine<double> tail =
@@ -673,6 +690,7 @@ void SvgRenderer::renderEdgeTripGeom(const RenderGraph &outG,
                        markerName.str() + "_m");
         renderLinePart(revSecond, lineW, *line, css, oCss);
       } else {
+        double tailWorld = 15.0 / _cfg->outputResolution;
         if (_cfg->renderMarkersTail) {
           double tailStart = std::max(0.0, revSecond.getLength() - tailWorld);
           PolyLine<double> tail =


### PR DESCRIPTION
## Summary
- Ensure bidirectional edges render a single centered tail and markers at both ends
- Prevent double tails by splitting path into halves and attaching markers only on endpoints

## Testing
- `cmake ..` *(fails: The source directory /workspace/loom/src/util does not contain a CMakeLists.txt file)*
- `git submodule update --init --recursive` *(fails: unable to access repositories: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_68aae616499c832da9cc6963549b4cf5