### PR TITLE
Add top-left ratio option for transitmap renderer

### DIFF
--- a/src/transitmap/config/ConfigReader.cpp
+++ b/src/transitmap/config/ConfigReader.cpp
@@ -96,6 +96,8 @@ void ConfigReader::help(const char *bin) const {
             << "input line smoothing\n"
             << std::setw(37) << "  --ratio arg (=-1)"
             << "output width/height ratio\n"
+            << std::setw(37) << "  --tl-ratio arg"
+            << "top-left anchored width/height ratio\n"
             << std::setw(37) << "  --random-colors"
             << "fill missing colors with random colors\n"
             << std::setw(37) << "  --tight-stations"
@@ -141,6 +143,7 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
                          {"padding-left", required_argument, 0, 26},
                          {"smoothing", required_argument, 0, 14},
                          {"ratio", required_argument, 0, 27},
+                         {"tl-ratio", required_argument, 0, 31},
                          {"render-node-fronts", no_argument, 0, 15},
                          {"crowded-line-thresh", required_argument, 0, 28},
                          {"sharp-turn-angle", required_argument, 0, 29},
@@ -226,6 +229,13 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
       break;
     case 27:
       cfg->ratio = atof(optarg);
+      break;
+    case 31:
+      cfg->tlRatio = atof(optarg);
+      cfg->paddingRight = 50;
+      cfg->paddingBottom = 50;
+      cfg->paddingTop = 0;
+      cfg->paddingLeft = 0;
       break;
     case 15:
       cfg->renderNodeFronts = true;
@@ -377,6 +387,10 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
 
   if (cfg->ratio != -1 && cfg->ratio <= 0) {
     std::cerr << "Error: ratio " << cfg->ratio << " is not positive!" << std::endl;
+    exit(1);
+  }
+  if (cfg->tlRatio != -1 && cfg->tlRatio <= 0) {
+    std::cerr << "Error: tl-ratio " << cfg->tlRatio << " is not positive!" << std::endl;
     exit(1);
   }
 }

--- a/src/transitmap/config/TransitMapConfig.h
+++ b/src/transitmap/config/TransitMapConfig.h
@@ -42,6 +42,7 @@ struct Config {
   double paddingLeft = -1;
 
   double ratio = -1;
+  double tlRatio = -1;
 
   double outlineWidth = 1;
   std::string outlineColor;

--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -88,6 +88,24 @@ void SvgRenderer::print(const RenderGraph &outG) {
     }
   }
 
+  if (_cfg->tlRatio > 0) {
+    double curWidth = box.getUpperRight().getX() - box.getLowerLeft().getX();
+    double curHeight = box.getUpperRight().getY() - box.getLowerLeft().getY();
+    double desiredWidth = curHeight * _cfg->tlRatio;
+    if (desiredWidth > curWidth) {
+      double pad = desiredWidth - curWidth;
+      DPoint nll(box.getLowerLeft().getX() - pad, box.getLowerLeft().getY());
+      DPoint nur(box.getUpperRight().getX(), box.getUpperRight().getY());
+      box = util::geo::Box<double>(nll, nur);
+    } else if (desiredWidth < curWidth) {
+      double desiredHeight = curWidth / _cfg->tlRatio;
+      double pad = desiredHeight - curHeight;
+      DPoint nll(box.getLowerLeft().getX(), box.getLowerLeft().getY());
+      DPoint nur(box.getUpperRight().getX(), box.getUpperRight().getY() + pad);
+      box = util::geo::Box<double>(nll, nur);
+    }
+  }
+
   if (!_cfg->worldFilePath.empty()) {
     std::ofstream file;
     file.open(_cfg->worldFilePath);


### PR DESCRIPTION
## Summary
- support `--tl-ratio` CLI option and `tlRatio` config field
- adjust SVG renderer to honor top-left anchored aspect ratio

## Testing
- `cmake ..` *(fails: The source directory /workspace/loom/src/util does not contain a CMakeLists.txt file)*
- `git submodule update --init --recursive` *(fails: unable to access GitHub repositories: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8398aef8832d8d8c488e2a64e09e