### PR TITLE
Track line terminals and expose in RenderGraph

### DIFF
--- a/src/gtfs2graph/builder/Builder.cpp
+++ b/src/gtfs2graph/builder/Builder.cpp
@@ -54,7 +54,7 @@ void Builder::consume(const Feed& f, BuildGraph* g) {
 
     auto prev = *st;
     const Edge* prevEdge = 0;
-    addStop(prev.getStop(), g, &ngrid);
+    Node* firstNode = addStop(prev.getStop(), g, &ngrid);
     ++st;
 
     if (i % 100 == 0)
@@ -92,6 +92,13 @@ void Builder::consume(const Feed& f, BuildGraph* g) {
       prev = cur;
       prevEdge = exE;
     }
+
+    // record terminal nodes for this route
+    Node* lastNode = getNodeByStop(g, prev.getStop());
+    if (firstNode)
+      _terminals[t->second->getRoute()].insert(firstNode);
+    if (lastNode)
+      _terminals[t->second->getRoute()].insert(lastNode);
   }
 }
 

--- a/src/gtfs2graph/builder/Builder.h
+++ b/src/gtfs2graph/builder/Builder.h
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <unordered_map>
+#include <set>
 #include "ad/cppgtfs/gtfs/Feed.h"
 #include "gtfs2graph/config/GraphBuilderConfig.h"
 #include "gtfs2graph/graph/BuildGraph.h"
@@ -43,10 +44,20 @@ class Builder {
   // simplify the BuildGraph
   void simplify(BuildGraph* g);
 
+  // access recorded terminal nodes per route
+  const std::unordered_map<const ad::cppgtfs::gtfs::Route*,
+                           std::set<Node*>>& getTerminals() const {
+    return _terminals;
+  }
+
  private:
   const config::Config* _cfg;
 
   std::map<const ad::cppgtfs::gtfs::Stop*, Node*> _stopNodes;
+
+  // mapping from GTFS routes to their terminal nodes
+  std::unordered_map<const ad::cppgtfs::gtfs::Route*, std::set<Node*>>
+      _terminals;
 
   // map of compiled polylines, to avoid calculating them each time
   std::unordered_map<ad::cppgtfs::gtfs::Shape*, PolyLine<double>> _polyLines;

--- a/src/shared/linegraph/LineGraph.cpp
+++ b/src/shared/linegraph/LineGraph.cpp
@@ -1285,16 +1285,6 @@ bool LineGraph::terminatesAt(const LineEdge* fromEdge, const LineNode* terminus,
 }
 
 // _____________________________________________________________________________
-bool LineGraph::terminatesAt(const LineNode* n, const Line* line) {
-  size_t count = 0;
-  for (auto e : n->getAdjList()) {
-    if (e->pl().hasLine(line) && ++count > 1) {
-      return false;
-    }
-  }
-  return count == 1;
-}
-
 // _____________________________________________________________________________
 double LineGraph::searchSpaceSize() const {
   double ret = 1;

--- a/src/shared/linegraph/LineGraph.h
+++ b/src/shared/linegraph/LineGraph.h
@@ -121,8 +121,6 @@ class LineGraph : public util::graph::UndirGraph<LineNodePL, LineEdgePL> {
   static bool terminatesAt(const LineEdge* fromEdge, const LineNode* terminus,
                            const Line* line);
 
-  static bool terminatesAt(const LineNode* n, const Line* line);
-
   static bool isTerminus(const LineNode* terminus);
 
   static std::vector<const Line*> getSharedLines(const LineEdge* a,

--- a/src/shared/rendergraph/RenderGraph.cpp
+++ b/src/shared/rendergraph/RenderGraph.cpp
@@ -86,6 +86,13 @@ bool RenderGraph::isTerminus(const LineNode* n) {
 }
 
 // _____________________________________________________________________________
+bool RenderGraph::lineTerminatesAt(const LineNode* n, const Line* line) const {
+  auto it = _lineTerminals.find(line);
+  if (it == _lineTerminals.end()) return false;
+  return it->second.find(n) != it->second.end();
+}
+
+// _____________________________________________________________________________
 std::vector<InnerGeom> RenderGraph::innerGeoms(const LineNode* n,
                                                double prec) const {
   std::vector<InnerGeom> ret;

--- a/src/shared/rendergraph/RenderGraph.h
+++ b/src/shared/rendergraph/RenderGraph.h
@@ -7,6 +7,7 @@
 
 #include <set>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "shared/linegraph/Line.h"
@@ -89,12 +90,25 @@ class RenderGraph : public shared::linegraph::LineGraph {
   static double getOutAngle(const shared::linegraph::LineNode* n,
                             const shared::linegraph::LineEdge* e);
 
+  bool lineTerminatesAt(const shared::linegraph::LineNode* n,
+                        const shared::linegraph::Line* line) const;
+
+  void setLineTerminals(
+      const std::unordered_map<const shared::linegraph::Line*,
+                               std::set<const shared::linegraph::LineNode*>>&
+          terms) {
+    _lineTerminals = terms;
+  }
+
   // Access landmark icons.
   const std::vector<Landmark>& getLandmarks() const { return _landmarks; }
   void addLandmark(const Landmark& lm) { _landmarks.push_back(lm); }
 
  private:
   double _defWidth, _defOutlineWidth, _defSpacing;
+  std::unordered_map<const shared::linegraph::Line*,
+                     std::set<const shared::linegraph::LineNode*>>
+      _lineTerminals;
 
   shared::rendergraph::InnerGeom getInnerBezier(
       const shared::linegraph::LineNode* n,

--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -1159,8 +1159,7 @@ void SvgRenderer::renderTerminusLabels(const RenderGraph &g,
     std::set<const Line *> seen;
     for (auto e : n->getAdjList()) {
       for (const auto &lo : e->pl().getLines()) {
-        if (seen.insert(lo.line).second &&
-            RenderGraph::terminatesAt(n, lo.line)) {
+        if (seen.insert(lo.line).second && g.lineTerminatesAt(n, lo.line)) {
           lines.insert(lo.line);
         }
       }


### PR DESCRIPTION
## Summary
- Record first and last stop nodes per GTFS route in the GTFS builder
- Store per-line terminal nodes in RenderGraph and provide lookup helpers
- Use terminal-node lookup for SVG terminus labels and drop degree-based check

## Testing
- `cmake ..` *(fails: The source directory /workspace/loom/src/util does not contain a CMakeLists.txt file)*

------
https://chatgpt.com/codex/tasks/task_e_68ad40c79428832dbea1705b7c1d9db0