### PR TITLE
Add configurable gap for terminus route labels

### DIFF
--- a/src/transitmap/config/ConfigReader.cpp
+++ b/src/transitmap/config/ConfigReader.cpp
@@ -71,6 +71,8 @@ void ConfigReader::help(const char *bin) const {
             << "textsize for line labels\n"
             << std::setw(37) << "  --station-label-textsize arg (=60)"
             << "textsize for station labels\n"
+            << std::setw(37) << "  --route-label-gap arg (=5)"
+            << "gap between station and route labels\n"
             << std::setw(37) << "  --no-deg2-labels"
             << "no labels for deg-2 stations\n"
 #ifdef PROTOBUF_FOUND
@@ -128,6 +130,7 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
                          {"no-deg2-labels", no_argument, 0, 16},
                          {"line-label-textsize", required_argument, 0, 5},
                          {"station-label-textsize", required_argument, 0, 6},
+                         {"route-label-gap", required_argument, 0, 32},
                          {"no-render-stations", no_argument, 0, 7},
                          {"labels", no_argument, 0, 'l'},
                          {"route-labels", no_argument, 0, 'r'},
@@ -184,6 +187,9 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
       break;
     case 6:
       cfg->stationLabelSize = atof(optarg);
+      break;
+    case 32:
+      cfg->routeLabelGap = atof(optarg);
       break;
     case 7:
       cfg->renderStations = false;

--- a/src/transitmap/config/TransitMapConfig.h
+++ b/src/transitmap/config/TransitMapConfig.h
@@ -24,6 +24,7 @@ struct Config {
 
   double lineLabelSize = 40;
   double stationLabelSize = 60;
+  double routeLabelGap = 5;
 
   std::string renderMethod = "svg";
 


### PR DESCRIPTION
## Summary
- compute rotation-aware station label edge in `renderTerminusLabels`
- use configurable `routeLabelGap` for spacing route labels
- expose `--route-label-gap` option in configuration

## Testing
- `cmake ..` *(fails: The source directory /workspace/loom/src/util does not contain a CMakeLists.txt file)*

------
https://chatgpt.com/codex/tasks/task_e_68ad576e216c832d807e02c53def373c