### PR TITLE
Add option to highlight terminal stations

### DIFF
--- a/src/transitmap/config/ConfigReader.cpp
+++ b/src/transitmap/config/ConfigReader.cpp
@@ -13,8 +13,8 @@
 #include "transitmap/_config.h"
 #include "transitmap/config/ConfigReader.h"
 #include "util/String.h"
-#include "util/log/Log.h"
 #include "util/geo/Geo.h"
+#include "util/log/Log.h"
 
 using std::exception;
 using transitmapper::config::ConfigReader;
@@ -63,7 +63,7 @@ void ConfigReader::help(const char *bin) const {
             << "lines on edge to trigger direction marker\n"
             << std::setw(37) << "  --sharp-turn-angle arg (=0.785398)"
             << "turn angle in radians to trigger direction marker\n"
-            << std::setw(37) << "  -l [ --labels ]" 
+            << std::setw(37) << "  -l [ --labels ]"
             << "render labels\n"
             << std::setw(37) << "  -r [ --route-labels ]"
             << "render route names at line termini\n"
@@ -73,6 +73,8 @@ void ConfigReader::help(const char *bin) const {
             << "textsize for station labels\n"
             << std::setw(37) << "  --route-label-gap arg (=5)"
             << "gap between station and route labels\n"
+            << std::setw(37) << "  --highlight-terminal"
+            << "highlight terminus stations\n"
             << std::setw(37) << "  --no-deg2-labels"
             << "no labels for deg-2 stations\n"
 #ifdef PROTOBUF_FOUND
@@ -108,14 +110,14 @@ void ConfigReader::help(const char *bin) const {
             << "don't render stations\n"
             << std::setw(37) << "  --no-render-node-connections"
             << "don't render inner node connections\n"
-            << std::setw(37) << "  --render-node-fronts" 
-            << "render node fronts\n" 
-            << std::setw(37) << "  --landmark arg" 
-            << "add landmark lat,lon or iconPath,lat,lon,size\n" 
-            << std::setw(37) << "  --landmarks arg" 
-            << "read landmarks from file, one iconPath,lat,lon,size per line\n" 
-            << std::setw(37) << "  --print-stats" 
-            << "write stats to stdout\n"; 
+            << std::setw(37) << "  --render-node-fronts"
+            << "render node fronts\n"
+            << std::setw(37) << "  --landmark arg"
+            << "add landmark lat,lon or iconPath,lat,lon,size\n"
+            << std::setw(37) << "  --landmarks arg"
+            << "read landmarks from file, one iconPath,lat,lon,size per line\n"
+            << std::setw(37) << "  --print-stats"
+            << "write stats to stdout\n";
 }
 
 // _____________________________________________________________________________
@@ -131,6 +133,7 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
                          {"line-label-textsize", required_argument, 0, 5},
                          {"station-label-textsize", required_argument, 0, 6},
                          {"route-label-gap", required_argument, 0, 32},
+                         {"highlight-terminal", no_argument, 0, 33},
                          {"no-render-stations", no_argument, 0, 7},
                          {"labels", no_argument, 0, 'l'},
                          {"route-labels", no_argument, 0, 'r'},
@@ -190,6 +193,9 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
       break;
     case 32:
       cfg->routeLabelGap = atof(optarg);
+      break;
+    case 33:
+      cfg->highlightTerminals = true;
       break;
     case 7:
       cfg->renderStations = false;
@@ -298,7 +304,8 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
       }
       std::string line;
       while (std::getline(infile, line)) {
-        if (line.empty()) continue;
+        if (line.empty())
+          continue;
         auto parts = util::split(line, ',');
         Landmark lm;
         if (parts.size() == 2) {
@@ -388,17 +395,23 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
   if (cfg->outputPadding < 0) {
     cfg->outputPadding = (cfg->lineWidth + cfg->lineSpacing);
   }
-  if (cfg->paddingTop < 0) cfg->paddingTop = cfg->outputPadding;
-  if (cfg->paddingRight < 0) cfg->paddingRight = cfg->outputPadding;
-  if (cfg->paddingBottom < 0) cfg->paddingBottom = cfg->outputPadding;
-  if (cfg->paddingLeft < 0) cfg->paddingLeft = cfg->outputPadding;
+  if (cfg->paddingTop < 0)
+    cfg->paddingTop = cfg->outputPadding;
+  if (cfg->paddingRight < 0)
+    cfg->paddingRight = cfg->outputPadding;
+  if (cfg->paddingBottom < 0)
+    cfg->paddingBottom = cfg->outputPadding;
+  if (cfg->paddingLeft < 0)
+    cfg->paddingLeft = cfg->outputPadding;
 
   if (cfg->ratio != -1 && cfg->ratio <= 0) {
-    std::cerr << "Error: ratio " << cfg->ratio << " is not positive!" << std::endl;
+    std::cerr << "Error: ratio " << cfg->ratio << " is not positive!"
+              << std::endl;
     exit(1);
   }
   if (cfg->tlRatio != -1 && cfg->tlRatio <= 0) {
-    std::cerr << "Error: tl-ratio " << cfg->tlRatio << " is not positive!" << std::endl;
+    std::cerr << "Error: tl-ratio " << cfg->tlRatio << " is not positive!"
+              << std::endl;
     exit(1);
   }
 }

--- a/src/transitmap/config/TransitMapConfig.h
+++ b/src/transitmap/config/TransitMapConfig.h
@@ -5,9 +5,9 @@
 #ifndef TRANSITMAP_CONFIG_TRANSITMAPCONFIG_H_
 #define TRANSITMAP_CONFIG_TRANSITMAPCONFIG_H_
 
+#include "util/geo/Geo.h"
 #include <string>
 #include <vector>
-#include "util/geo/Geo.h"
 
 namespace transitmapper {
 namespace config {
@@ -54,6 +54,7 @@ struct Config {
   bool renderEdges = true;
   bool renderLabels = false;
   bool renderRouteLabels = false;
+  bool highlightTerminals = false;
   bool dontLabelDeg2 = false;
   bool fromDot = false;
 
@@ -68,7 +69,7 @@ struct Config {
   bool renderMarkersTail = false;
   bool renderBiDirMarker = false;
   size_t crowdedLineThresh = 3;
-  double sharpTurnAngle = 0.7853981633974483;  // 45 degrees in radians
+  double sharpTurnAngle = 0.7853981633974483; // 45 degrees in radians
   std::string worldFilePath;
 
   std::vector<Landmark> landmarks;

--- a/src/transitmap/label/Labeller.cpp
+++ b/src/transitmap/label/Labeller.cpp
@@ -26,10 +26,10 @@
 #include "transitmap/label/Labeller.h"
 #include "util/geo/Geo.h"
 
+#include <cctype>
 #include <cmath>
 #include <set>
 #include <string>
-#include <cctype>
 #include <vector>
 
 #ifdef LOOM_HAVE_FREETYPE
@@ -62,8 +62,7 @@ std::vector<char32_t> decodeUtf8(const std::string &s) {
       cp = c;
       i += 1;
     } else if ((c >> 5) == 0x6 && i + 1 < s.size()) {
-      cp = ((c & 0x1F) << 6) |
-           (static_cast<unsigned char>(s[i + 1]) & 0x3F);
+      cp = ((c & 0x1F) << 6) | (static_cast<unsigned char>(s[i + 1]) & 0x3F);
       i += 2;
     } else if ((c >> 4) == 0xE && i + 2 < s.size()) {
       cp = ((c & 0x0F) << 12) |
@@ -296,6 +295,9 @@ void Labeller::labelStations(const RenderGraph &g, bool notdeg2) {
 
   for (auto n : orderedNds) {
     double fontSize = _cfg->stationLabelSize;
+    if (_cfg->highlightTerminals && g.isTerminus(n)) {
+      fontSize += 1;
+    }
     int prefDeg = 0;
     if (n->pl().stops().size()) {
       const auto &sp = n->pl().stops().front().pos;

--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -227,7 +227,9 @@ void SvgRenderer::outputNodes(const RenderGraph &outG,
       params["stroke"] = "black";
       params["stroke-width"] =
           util::toString((_cfg->lineWidth / 2) * _cfg->outputResolution);
-      params["fill"] = "white";
+      params["fill"] = (_cfg->highlightTerminals && RenderGraph::isTerminus(n))
+                           ? "black"
+                           : "white";
 
       for (const auto &geom : outG.getStopGeoms(n, _cfg->tightStations, 32)) {
         printPolygon(geom, params, rparams);
@@ -634,7 +636,8 @@ bool SvgRenderer::needsDirMarker(const shared::linegraph::LineEdge *e,
     double dot = ux * vx + uy * vy;
     double lu = std::sqrt(ux * ux + uy * uy);
     double lv = std::sqrt(vx * vx + vy * vy);
-    if (lu == 0 || lv == 0) continue;
+    if (lu == 0 || lv == 0)
+      continue;
     double cosang = dot / (lu * lv);
     cosang = std::max(-1.0, std::min(1.0, cosang));
     double ang = std::acos(cosang);
@@ -653,14 +656,15 @@ bool SvgRenderer::needsDirMarker(const shared::linegraph::LineEdge *e,
     if (fromStart) {
       otherE = plE.getPointAtDist(std::min(checkDist, lenE)).p;
     } else {
-      otherE =
-          plE.getPointAtDist(std::max(0.0, lenE - checkDist)).p;
+      otherE = plE.getPointAtDist(std::max(0.0, lenE - checkDist)).p;
     }
     double ux = otherE.getX() - base.getX();
     double uy = otherE.getY() - base.getY();
     for (auto ne : n->getAdjList()) {
-      if (ne == e) continue;
-      if (!ne->pl().hasLine(line)) continue;
+      if (ne == e)
+        continue;
+      if (!ne->pl().hasLine(line))
+        continue;
       PolyLine<double> plN(*ne->pl().getGeom());
       double lenN = plN.getLength();
       DPoint baseN = (ne->getFrom() == n) ? plN.front() : plN.back();
@@ -668,15 +672,15 @@ bool SvgRenderer::needsDirMarker(const shared::linegraph::LineEdge *e,
       if (ne->getFrom() == n) {
         otherN = plN.getPointAtDist(std::min(checkDist, lenN)).p;
       } else {
-        otherN =
-            plN.getPointAtDist(std::max(0.0, lenN - checkDist)).p;
+        otherN = plN.getPointAtDist(std::max(0.0, lenN - checkDist)).p;
       }
       double vx = otherN.getX() - baseN.getX();
       double vy = otherN.getY() - baseN.getY();
       double dot = ux * vx + uy * vy;
       double lu = std::sqrt(ux * ux + uy * uy);
       double lv = std::sqrt(vx * vx + vy * vy);
-      if (lu == 0 || lv == 0) continue;
+      if (lu == 0 || lv == 0)
+        continue;
       double cosang = dot / (lu * lv);
       cosang = std::max(-1.0, std::min(1.0, cosang));
       double ang = std::acos(cosang);
@@ -757,8 +761,7 @@ void SvgRenderer::renderEdgeTripGeom(const RenderGraph &outG,
       oCss = lo.style.get().getOutlineCss();
     }
 
-    bool needMarker =
-        _cfg->renderDirMarkers && needsDirMarker(e, center, line);
+    bool needMarker = _cfg->renderDirMarkers && needsDirMarker(e, center, line);
     bool drawMarker = needMarker && center.getLength() > arrowLength * 3;
 
     if (drawMarker) {
@@ -792,8 +795,7 @@ void SvgRenderer::renderEdgeTripGeom(const RenderGraph &outG,
           double tailEnd = mid + tailWorld / 2;
 
           PolyLine<double> firstHalf = p.getSegmentAtDist(0, mid);
-          PolyLine<double> secondHalf =
-              p.getSegmentAtDist(mid, p.getLength());
+          PolyLine<double> secondHalf = p.getSegmentAtDist(mid, p.getLength());
           PolyLine<double> revFirstHalf = firstHalf.reversed();
 
           if (_cfg->renderMarkersTail) {
@@ -803,8 +805,7 @@ void SvgRenderer::renderEdgeTripGeom(const RenderGraph &outG,
 
             PolyLine<double> tailToStart =
                 p.getSegmentAtDist(tailStart, mid).reversed();
-            PolyLine<double> tailToEnd =
-                p.getSegmentAtDist(mid, tailEnd);
+            PolyLine<double> tailToEnd = p.getSegmentAtDist(mid, tailEnd);
             renderLinePart(tailToStart, lineW, *line, "stroke:black",
                            "stroke:none", markerName.str() + "_mt");
             renderLinePart(tailToEnd, lineW, *line, "stroke:black",


### PR DESCRIPTION
## Summary
- add `--highlight-terminal` flag to ConfigReader and config
- boost terminus station label size when highlighting
- render terminus station nodes with black fill when highlighting

## Testing
- `cmake -S . -B build` *(fails: The source directory `/workspace/loom/src/util` does not contain a CMakeLists.txt file)*
- `clang-format -i src/transitmap/config/TransitMapConfig.h src/transitmap/config/ConfigReader.cpp src/transitmap/label/Labeller.cpp src/transitmap/output/SvgRenderer.cpp`

------
https://chatgpt.com/codex/tasks/task_e_68ad8ee249b8832db864e4ee7e7c07fb