### PR TITLE
Separate route label spacing for boxes and terminus

### DIFF
--- a/src/transitmap/config/ConfigReader.cpp
+++ b/src/transitmap/config/ConfigReader.cpp
@@ -71,8 +71,10 @@ void ConfigReader::help(const char *bin) const {
             << "textsize for line labels\n"
             << std::setw(37) << "  --station-label-textsize arg (=60)"
             << "textsize for station labels\n"
-            << std::setw(37) << "  --route-label-gap arg (=5)"
-            << "gap between station and route labels\n"
+            << std::setw(37) << "  --route-label-gap arg (=20)"
+            << "gap between route label boxes\n"
+            << std::setw(37) << "  --route-label-terminus-gap arg (=100)"
+            << "gap between terminus station label and route labels\n"
             << std::setw(37) << "  --highlight-terminal"
             << "highlight terminus stations\n"
             << std::setw(37) << "  --no-deg2-labels"
@@ -133,6 +135,7 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
                          {"line-label-textsize", required_argument, 0, 5},
                          {"station-label-textsize", required_argument, 0, 6},
                          {"route-label-gap", required_argument, 0, 32},
+                         {"route-label-terminus-gap", required_argument, 0, 34},
                          {"highlight-terminal", no_argument, 0, 33},
                          {"no-render-stations", no_argument, 0, 7},
                          {"labels", no_argument, 0, 'l'},
@@ -192,7 +195,10 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
       cfg->stationLabelSize = atof(optarg);
       break;
     case 32:
-      cfg->routeLabelGap = atof(optarg);
+      cfg->routeLabelBoxGap = atof(optarg);
+      break;
+    case 34:
+      cfg->routeLabelTerminusGap = atof(optarg);
       break;
     case 33:
       cfg->highlightTerminals = true;

--- a/src/transitmap/config/TransitMapConfig.h
+++ b/src/transitmap/config/TransitMapConfig.h
@@ -24,7 +24,10 @@ struct Config {
 
   double lineLabelSize = 40;
   double stationLabelSize = 60;
-  double routeLabelGap = 5;
+  // Gap between consecutive route label boxes.
+  double routeLabelBoxGap = 20;
+  // Gap between the terminus station label and the first route label box.
+  double routeLabelTerminusGap = 100;
 
   std::string renderMethod = "svg";
 

--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -1241,9 +1241,10 @@ void SvgRenderer::renderTerminusLabels(const RenderGraph &g,
     // Use a uniform gap to achieve consistent spacing regardless of the
     // orientation of the station label. The gap is configurable to allow
     // tuning without recompilation.
-    double gap = _cfg->routeLabelGap * _cfg->outputResolution;
-    double startY = above ? y - boxH - gap : y + gap;
-    double step = boxH + gap;
+    double boxGap = _cfg->routeLabelBoxGap * _cfg->outputResolution;
+    double terminusGap = _cfg->routeLabelTerminusGap * _cfg->outputResolution;
+    double startY = above ? y - boxH - terminusGap : y + terminusGap;
+    double step = boxH + boxGap;
 
     for (auto line : lines) {
       std::string label = line->label();


### PR DESCRIPTION
## Summary
- split single `routeLabelGap` into `routeLabelBoxGap` and `routeLabelTerminusGap`
- expose new command line option `--route-label-terminus-gap`
- respect both gaps when laying out route label boxes in SVG renderer

## Testing
- `cmake -S . -B build` *(fails: src/util and src/cppgtfs submodules missing)*
- `git submodule update --init --recursive` *(fails: CONNECT tunnel 403)*
- `ctest --test-dir build` *(no tests found after failed build)*

------
https://chatgpt.com/codex/tasks/task_e_68ad9183bb54832d84c6080d3635af71