### PR TITLE
Scale terminus label width when font size changes

### DIFF
--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -1219,6 +1219,16 @@ void SvgRenderer::renderTerminusLabels(const RenderGraph &g,
       double hdy = top[0].getY() - base[0].getY();
       double height = std::sqrt(hdx * hdx + hdy * hdy);
 
+      // If the font size changed after the label band was computed, adjust
+      // the label dimensions accordingly to avoid overlaps.
+      double scale = sLbl->fontSize / _cfg->stationLabelSize;
+      if (scale != 1.0) {
+        centerX += dx * (scale - 1.0) / 2.0;
+        centerY += dy * (scale - 1.0) / 2.0;
+        width *= scale;
+        height *= scale;
+      }
+
       double vExtent;
       double absTan = std::abs(std::tan(angle));
       if (absTan <= width / height) {


### PR DESCRIPTION
## Summary
- adjust terminus label placement to rescale width and height when station label font size differs from configuration

## Testing
- `cmake -S . -B build` *(fails: The source directory /workspace/loom/src/util does not contain a CMakeLists.txt file)*

------
https://chatgpt.com/codex/tasks/task_e_68ad9dd38b70832d9c74a5a2298e0792