### PR TITLE
Default terminus route labels below station

### DIFF
--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -1186,7 +1186,7 @@ void SvgRenderer::renderTerminusLabels(const RenderGraph &g,
 
     double anchorX = nodeX;
     double anchorY = nodeY;
-    bool above = true;
+    bool above = false;
     if (sLbl) {
       const auto &base = sLbl->band[0];
       const auto &top = sLbl->band[2];


### PR DESCRIPTION
## Summary
- Start route label boxes for terminus stations below the stop
- Preserve logic to move them above the stop when a station label sits above

## Testing
- `cmake -S . -B build` *(fails: The source directory `/workspace/loom/src/util` does not contain a CMakeLists.txt file)*
- `git submodule update --init --recursive` *(fails: unable to access required git submodules)*

------
https://chatgpt.com/codex/tasks/task_e_68ada7d27e0c832da84385acf347b5a9