### PR TITLE
Fix terminus label vertical positioning

### DIFF
--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -1211,7 +1211,7 @@ void SvgRenderer::renderTerminusLabels(const RenderGraph &g,
 
       double centerX = (minX + maxX) / 2;
       double centerY = (minY + maxY) / 2;
-      above = centerY > nodeY;
+      above = centerY < nodeY;
 
       // Determine label dimensions and rotation to derive a rotation-aware
       // distance from the label center to its outer edge along the vertical
@@ -1234,7 +1234,7 @@ void SvgRenderer::renderTerminusLabels(const RenderGraph &g,
       }
 
       anchorX = centerX;
-      anchorY = above ? centerY + vExtent : centerY - vExtent;
+      anchorY = above ? centerY - vExtent : centerY + vExtent;
     }
 
     double x = (anchorX - rparams.xOff) * _cfg->outputResolution;


### PR DESCRIPTION
## Summary
- ensure terminus route labels only flip above when their center is higher than the station
- anchor label boxes at the near edge to keep spacing consistent

## Testing
- `cmake ..` *(fails: /workspace/loom/src/util does not contain a CMakeLists.txt file)*
- `git submodule update --init --recursive` *(fails: unable to access 'https://github.com/ad-freiburg/cppgtfs.git/' - CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_68adb3b62a70832db48a6b3a5544b626