### PR TITLE
feat: round terminus route label boxes

### DIFF
--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -1246,6 +1246,7 @@ void SvgRenderer::renderTerminusLabels(const RenderGraph &g,
     double boxH = fontSize + pad * 2;
     double charW = fontSize * 0.6;
     double boxW = 5 * charW + pad * 2; // uniform width for up to 4 chars
+    double boxR = pad;
 
     size_t idx = 0;
     // Use a uniform gap to achieve consistent spacing regardless of the
@@ -1268,6 +1269,8 @@ void SvgRenderer::renderTerminusLabels(const RenderGraph &g,
                           {"y", util::toString(rectY)},
                           {"width", util::toString(boxW)},
                           {"height", util::toString(boxH)},
+                          {"rx", util::toString(boxR)},
+                          {"ry", util::toString(boxR)},
                           {"fill", "#" + fillColor}});
       _w.closeTag();
 


### PR DESCRIPTION
## Summary
- round terminus route label boxes with radius based on padding for softer appearance

## Testing
- `cmake ..` *(fails: The source directory /workspace/loom/src/util does not contain a CMakeLists.txt file)*
- `git submodule update --init --recursive` *(fails: unable to access https://github.com/ad-freiburg/cppgtfs.git/)*

------
https://chatgpt.com/codex/tasks/task_e_68adb53ea788832d848d6a38cd4060ca