### PR TITLE
Expand station label overlap search radius

### DIFF
--- a/src/transitmap/label/Labeller.h
+++ b/src/transitmap/label/Labeller.h
@@ -139,7 +139,8 @@ class Labeller {
 
   Overlaps getOverlaps(const util::geo::MultiLine<double>& band,
                        const shared::linegraph::LineNode* forNd,
-                       const shared::rendergraph::RenderGraph& g) const;
+                       const shared::rendergraph::RenderGraph& g,
+                       double radius) const;
 
   util::geo::MultiLine<double> getStationLblBand(
       const shared::linegraph::LineNode* n, double fontSize, uint8_t offset,


### PR DESCRIPTION
## Summary
- Include station label size and bounding box when computing overlap search radius
- Allow `getOverlaps` to accept a custom radius and use it for edge, label, and landmark checks

## Testing
- `cmake -S . -B build` *(fails: The source directory /workspace/loom/src/util does not contain a CMakeLists.txt file)*

------
https://chatgpt.com/codex/tasks/task_e_68adc65c98c4832dae9bacb6e3235bcd