### PR TITLE
configurable station-line overlap penalty

### DIFF
--- a/src/transitmap/config/ConfigReader.cpp
+++ b/src/transitmap/config/ConfigReader.cpp
@@ -71,6 +71,9 @@ void ConfigReader::help(const char *bin) const {
             << "textsize for line labels\n"
             << std::setw(37) << "  --station-label-textsize arg (=60)"
             << "textsize for station labels\n"
+            << std::setw(37)
+            << "  --station-line-overlap-penalty arg (=15)"
+            << "penalty multiplier for station-line overlaps\n"
             << std::setw(37) << "  --route-label-gap arg (=20)"
             << "gap between route label boxes\n"
             << std::setw(37) << "  --route-label-terminus-gap arg (=100)"
@@ -134,6 +137,7 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
                          {"no-deg2-labels", no_argument, 0, 16},
                          {"line-label-textsize", required_argument, 0, 5},
                          {"station-label-textsize", required_argument, 0, 6},
+                         {"station-line-overlap-penalty", required_argument, 0, 35},
                          {"route-label-gap", required_argument, 0, 32},
                          {"route-label-terminus-gap", required_argument, 0, 34},
                          {"highlight-terminal", no_argument, 0, 33},
@@ -193,6 +197,9 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
       break;
     case 6:
       cfg->stationLabelSize = atof(optarg);
+      break;
+    case 35:
+      cfg->stationLineOverlapPenalty = atof(optarg);
       break;
     case 32:
       cfg->routeLabelBoxGap = atof(optarg);

--- a/src/transitmap/config/TransitMapConfig.h
+++ b/src/transitmap/config/TransitMapConfig.h
@@ -24,6 +24,7 @@ struct Config {
 
   double lineLabelSize = 40;
   double stationLabelSize = 60;
+  double stationLineOverlapPenalty = 15;
   // Gap between consecutive route label boxes.
   double routeLabelBoxGap = 10;
   // Gap between the terminus station label and the first route label box.

--- a/src/transitmap/label/Labeller.cpp
+++ b/src/transitmap/label/Labeller.cpp
@@ -339,7 +339,8 @@ void Labeller::labelStations(const RenderGraph &g, bool notdeg2) {
                              : 0;
         cands.emplace_back(PolyLine<double>(band[0]), band, fontSize,
                            isTerminus, deg, offset, overlaps,
-                           sidePen + termPen, station);
+                           sidePen + termPen, _cfg->stationLineOverlapPenalty,
+                           station);
       }
     }
 

--- a/src/transitmap/label/Labeller.h
+++ b/src/transitmap/label/Labeller.h
@@ -63,13 +63,15 @@ struct StationLabel {
 
   // penalty to discourage placing labels on the wrong side of the road
   double sidePen = 0;
+  double lineOverlapPenalty = 15;
 
   shared::linegraph::Station s;
 
   StationLabel(const util::geo::PolyLine<double>& geom,
                const util::geo::MultiLine<double>& band, double fontSize,
                bool bold, size_t deg, size_t pos, const Overlaps& overlaps,
-               double sidePen, const shared::linegraph::Station& s)
+               double sidePen, double lineOverlapPenalty,
+               const shared::linegraph::Station& s)
       : geom(geom),
         band(band),
         fontSize(fontSize),
@@ -78,10 +80,12 @@ struct StationLabel {
         pos(pos),
         overlaps(overlaps),
         sidePen(sidePen),
+        lineOverlapPenalty(lineOverlapPenalty),
         s(s) {}
 
   double getPen() const {
-    double score = overlaps.lineOverlaps * 15 + overlaps.statOverlaps * 20 +
+    double score = overlaps.lineOverlaps * lineOverlapPenalty +
+                   overlaps.statOverlaps * 20 +
                    overlaps.statLabelOverlaps * 20 +
                    overlaps.lineLabelOverlaps * 15 +
                    overlaps.landmarkOverlaps * 20 +


### PR DESCRIPTION
## Summary
- Add `stationLineOverlapPenalty` to configuration with default `15`
- Use configurable penalty in `StationLabel` scoring instead of hard-coded value
- Parse new `--station-line-overlap-penalty` option in `ConfigReader`

## Testing
- `cmake ..` *(fails: The source directory /workspace/loom/src/util does not contain a CMakeLists.txt file)*

------
https://chatgpt.com/codex/tasks/task_e_68adc66b2a30832dbcf2f51612c12087