### PR TITLE
Expand landmark parsing to support words

### DIFF
--- a/src/transitmap/config/TransitMapConfig.h
+++ b/src/transitmap/config/TransitMapConfig.h
@@ -14,6 +14,8 @@ namespace config {
 
 struct Landmark {
   std::string iconPath;
+  std::string label;
+  std::string color = "#000";
   util::geo::DPoint coord;
   double size = 200;
 };


### PR DESCRIPTION
## Summary
- Add label and color fields to `Landmark` config structure
- Support `word:<text>,lat,lon[,size[,color]]` in `--landmark` and `--landmarks` options
- Clarify landmark parsing errors and usage text

## Testing
- `cmake ..` *(fails: The source directory /workspace/loom/src/util does not contain a CMakeLists.txt file)*

------
https://chatgpt.com/codex/tasks/task_e_68add3889a28832d82b81ac0dd6795b0