### PR TITLE
Render landmarks before other SVG elements for proper z-order

### DIFF
--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -158,6 +158,11 @@ void SvgRenderer::print(const RenderGraph &outG) {
   }
   _w.openTag("svg", params);
 
+  // render landmarks before edges and nodes to put them at the lowest
+  // z-order. Icons/text will be drawn first so subsequent elements can
+  // overlay them.
+  renderLandmarks(outG, rparams);
+
   _w.openTag("defs");
 
   LOGTO(DEBUG, std::cerr) << "Rendering markers...";
@@ -184,11 +189,6 @@ void SvgRenderer::print(const RenderGraph &outG) {
   }
 
   _w.closeTag();
-
-  // render landmarks before edges and nodes to put them at the lowest
-  // z-order. Icons/text will be drawn first so subsequent elements can
-  // overlay them.
-  renderLandmarks(outG, rparams);
 
   LOGTO(DEBUG, std::cerr) << "Rendering nodes...";
   for (auto n : outG.getNds()) {


### PR DESCRIPTION
## Summary
- Invoke `renderLandmarks` immediately after opening the `<svg>` so icons/text render beneath edges and nodes.

## Testing
- `cmake -S . -B build` *(fails: missing submodules `src/util` and `src/cppgtfs` and other dependencies)*
- `git submodule update --init --recursive` *(fails: network access to required repositories blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68addd96351c832da281d5adf4f0ae8c