### PR TITLE
Remove unused getLandmarks from Labeller

### DIFF
--- a/src/transitmap/label/Labeller.cpp
+++ b/src/transitmap/label/Labeller.cpp
@@ -619,8 +619,3 @@ bool Labeller::addLandmark(const util::geo::Box<double> &box) {
   _landmarks.push_back(box);
   return true;
 }
-
-// _____________________________________________________________________________
-const std::vector<util::geo::Box<double>> &Labeller::getLandmarks() const {
-  return _landmarks;
-}

--- a/src/transitmap/label/Labeller.h
+++ b/src/transitmap/label/Labeller.h
@@ -119,10 +119,8 @@ class Labeller {
   const std::vector<LineLabel>& getLineLabels() const;
   const std::vector<StationLabel>& getStationLabels() const;
 
-  // Add and query landmark icons.
   bool addLandmark(const util::geo::Box<double>& box);
   bool collidesWithLabels(const util::geo::Box<double>& box) const;
-  const std::vector<util::geo::Box<double>>& getLandmarks() const;
 
   util::geo::Box<double> getBBox() const;
 


### PR DESCRIPTION
## Summary
- Drop `Labeller::getLandmarks` declaration and definition
- Clean up related comment in `Labeller` header

## Testing
- `cmake ..` *(fails: missing submodule CMakeLists.txt for src/util and src/cppgtfs)*

------
https://chatgpt.com/codex/tasks/task_e_68ade1286b94832d88d34fff018c3bdc