### PR TITLE
Filter unlabelled landmarks from SVG rendering

### DIFF
--- a/src/transitmap/output/SvgRenderer.h
+++ b/src/transitmap/output/SvgRenderer.h
@@ -110,8 +110,10 @@ class SvgRenderer : public Renderer {
   void renderNodeFronts(const shared::rendergraph::RenderGraph& outG,
                         const RenderParams& params);
 
-  void renderLandmarks(const shared::rendergraph::RenderGraph& g,
-                       const RenderParams& params);
+  void renderLandmarks(
+      const shared::rendergraph::RenderGraph& g,
+      const std::vector<shared::rendergraph::Landmark>& landmarks,
+      const RenderParams& params);
 
   void renderLineLabels(const label::Labeller& lbler,
                         const RenderParams& params);


### PR DESCRIPTION
## Summary
- Ignore landmarks rejected by the labeller to keep map bounds accurate
- Pass only accepted landmarks to the SVG rendering routine
- Update renderer interface to work with filtered landmark list

## Testing
- `cmake -S . -B build` *(fails: The source directory `/workspace/loom/src/util` does not contain a CMakeLists.txt file)*
- `git submodule update --init --recursive` *(fails: unable to access repositories; CONNECT tunnel failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ade2d7e5dc832d84c8c8d072606a1f