### PR TITLE
Skip overlapping text landmarks in SVG renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,8 +251,9 @@ Each landmark line is either
 * `iconPath,lat,lon[,size]` – place an SVG icon from `iconPath`. The optional
   `size` also defaults to `200`.
 
-Landmarks that would overlap with existing labels or previously placed
-landmarks are skipped. To render the sample landmarks alongside a map, run
+Landmarks that would overlap with existing labels, map features, or previously
+placed landmarks are skipped. To render the sample landmarks alongside a map,
+run
 
 ```
 cat examples/stuttgart.json | loom | transitmap --landmarks examples/landmarks.txt > stuttgart-landmarks.svg

--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -394,6 +394,9 @@ void SvgRenderer::renderLandmarks(const RenderGraph &g,
                          {"height", util::toString(lm.size)}});
       _w.closeTag();
     } else if (!lm.label.empty()) {
+      if (overlaps)
+        continue; // skip text landmarks overlapping existing geometry
+
       double x = (lm.coord.getX() - rparams.xOff) * _cfg->outputResolution;
       double y = rparams.height -
                  (lm.coord.getY() - rparams.yOff) * _cfg->outputResolution;
@@ -405,8 +408,6 @@ void SvgRenderer::renderLandmarks(const RenderGraph &g,
       params["text-anchor"] = "middle";
       params["fill"] = lm.color;
       params["font-family"] = "TT Norms Pro";
-      if (overlaps)
-        params["opacity"] = "0.2";
       _w.openTag("text", params);
       _w.writeText(lm.label);
       _w.closeTag();


### PR DESCRIPTION
## Summary
- avoid drawing text landmarks that overlap existing map features
- clarify README that overlapping landmarks are skipped

## Testing
- `cmake ..` *(fails: The source directory /workspace/loom/src/util does not contain a CMakeLists.txt file)*
- `git submodule update --init --recursive` *(fails: unable to access 'https://github.com/ad-freiburg/cppgtfs.git': CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ade66b29c4832db66452e832e43fae