### PR TITLE
Add configurable SVG font size cap for station labels

### DIFF
--- a/src/transitmap/config/ConfigReader.cpp
+++ b/src/transitmap/config/ConfigReader.cpp
@@ -76,6 +76,8 @@ void ConfigReader::help(const char *bin) const {
             << "max length/straight distance ratio for line label candidates\n"
             << std::setw(37) << "  --station-label-textsize arg (=60)"
             << "textsize for station labels\n"
+            << std::setw(37) << "  --font-svg-max arg (=11)"
+            << "max font size for station labels in SVG, -1 for no limit\n"
             << std::setw(37) << "  --station-line-overlap-penalty arg (=15)"
             << "penalty multiplier for station-line overlaps\n"
             << std::setw(37) << "  --route-label-gap arg (=20)"
@@ -122,9 +124,11 @@ void ConfigReader::help(const char *bin) const {
             << std::setw(37) << "  --render-node-fronts"
             << "render node fronts\n"
             << std::setw(37) << "  --landmark arg"
-            << "add landmark word:text,lat,lon[,size[,color]] or iconPath,lat,lon[,size]\n"
+            << "add landmark word:text,lat,lon[,size[,color]] or "
+               "iconPath,lat,lon[,size]\n"
             << std::setw(37) << "  --landmarks arg"
-            << "read landmarks from file, one word:text,lat,lon[,size[,color]] or iconPath,lat,lon[,size] per line\n"
+            << "read landmarks from file, one word:text,lat,lon[,size[,color]] "
+               "or iconPath,lat,lon[,size] per line\n"
             << std::setw(37) << "  --print-stats"
             << "write stats to stdout\n";
 }
@@ -144,6 +148,7 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
       {"line-label-bend-angle", required_argument, 0, 35},
       {"line-label-length-ratio", required_argument, 0, 36},
       {"station-label-textsize", required_argument, 0, 6},
+      {"font-svg-max", required_argument, 0, 38},
       {"station-line-overlap-penalty", required_argument, 0, 37},
       {"route-label-gap", required_argument, 0, 32},
       {"route-label-terminus-gap", required_argument, 0, 34},
@@ -210,6 +215,9 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
       break;
     case 6:
       cfg->stationLabelSize = atof(optarg);
+      break;
+    case 38:
+      cfg->fontSvgMax = atof(optarg);
       break;
     case 37:
       cfg->stationLineOverlapPenalty = atof(optarg);
@@ -318,7 +326,9 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
           lm.color = parts[4];
         if (parts.size() > 5) {
           std::cerr << "Error while parsing landmark " << optarg
-                    << " (expected word:<text>,lat,lon[,size[,color]] or iconPath,lat,lon[,size])" << std::endl;
+                    << " (expected word:<text>,lat,lon[,size[,color]] or "
+                       "iconPath,lat,lon[,size])"
+                    << std::endl;
           exit(1);
         }
       } else if (parts.size() >= 3) {
@@ -330,12 +340,16 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
           lm.size = atof(parts[3].c_str());
         if (parts.size() > 4) {
           std::cerr << "Error while parsing landmark " << optarg
-                    << " (expected word:<text>,lat,lon[,size[,color]] or iconPath,lat,lon[,size])" << std::endl;
+                    << " (expected word:<text>,lat,lon[,size[,color]] or "
+                       "iconPath,lat,lon[,size])"
+                    << std::endl;
           exit(1);
         }
       } else {
         std::cerr << "Error while parsing landmark " << optarg
-                  << " (expected word:<text>,lat,lon[,size[,color]] or iconPath,lat,lon[,size])" << std::endl;
+                  << " (expected word:<text>,lat,lon[,size[,color]] or "
+                     "iconPath,lat,lon[,size])"
+                  << std::endl;
         exit(1);
       }
 
@@ -365,7 +379,9 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
             lm.color = parts[4];
           if (parts.size() > 5) {
             std::cerr << "Error while parsing landmark " << line
-                      << " (expected word:<text>,lat,lon[,size[,color]] or iconPath,lat,lon[,size])" << std::endl;
+                      << " (expected word:<text>,lat,lon[,size[,color]] or "
+                         "iconPath,lat,lon[,size])"
+                      << std::endl;
             exit(1);
           }
         } else if (parts.size() >= 3) {
@@ -377,12 +393,16 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
             lm.size = atof(parts[3].c_str());
           if (parts.size() > 4) {
             std::cerr << "Error while parsing landmark " << line
-                      << " (expected word:<text>,lat,lon[,size[,color]] or iconPath,lat,lon[,size])" << std::endl;
+                      << " (expected word:<text>,lat,lon[,size[,color]] or "
+                         "iconPath,lat,lon[,size])"
+                      << std::endl;
             exit(1);
           }
         } else {
           std::cerr << "Error while parsing landmark " << line
-                    << " (expected word:<text>,lat,lon[,size[,color]] or iconPath,lat,lon[,size])" << std::endl;
+                    << " (expected word:<text>,lat,lon[,size[,color]] or "
+                       "iconPath,lat,lon[,size])"
+                    << std::endl;
           exit(1);
         }
         cfg->landmarks.push_back(lm);

--- a/src/transitmap/config/TransitMapConfig.h
+++ b/src/transitmap/config/TransitMapConfig.h
@@ -25,6 +25,8 @@ struct Config {
   double lineLabelLengthRatio = 1.1;
   double stationLabelSize = 60;
   double stationLineOverlapPenalty = 15;
+  // Maximum font size for station labels in SVG output; -1 for no limit.
+  double fontSvgMax = 11;
   // Gap between consecutive route label boxes.
   double routeLabelBoxGap = 10;
   // Gap between the terminus station label and the first route label box.

--- a/src/transitmap/label/Labeller.cpp
+++ b/src/transitmap/label/Labeller.cpp
@@ -2,9 +2,9 @@
 // Chair of Algorithms and Data Structures.
 // Authors: Patrick Brosi <brosi@informatik.uni-freiburg.de>
 
+#include <algorithm>
 #include <cmath>
 #include <string>
-#include <algorithm>
 #ifdef LOOM_HAVE_FREETYPE
 #ifdef Max
 #pragma push_macro("Max")
@@ -27,9 +27,9 @@
 #include "transitmap/label/Labeller.h"
 #include "util/geo/Geo.h"
 
+#include <algorithm>
 #include <cctype>
 #include <cmath>
-#include <algorithm>
 #include <set>
 #include <string>
 #include <vector>
@@ -302,6 +302,10 @@ void Labeller::labelStations(const RenderGraph &g, bool notdeg2) {
     if (_cfg->highlightTerminals && isTerminus) {
       fontSize += 10;
     }
+    if (_cfg->fontSvgMax >= 0 &&
+        fontSize * _cfg->outputResolution > _cfg->fontSvgMax) {
+      fontSize = _cfg->fontSvgMax / _cfg->outputResolution;
+    }
     int prefDeg = 0;
     if (n->pl().stops().size()) {
       const auto &sp = n->pl().stops().front().pos;
@@ -327,8 +331,7 @@ void Labeller::labelStations(const RenderGraph &g, bool notdeg2) {
         band = util::geo::rotate(band, 30 * deg, *n->pl().getGeom());
 
         auto box = util::geo::getBoundingBox(band);
-        double diag =
-            util::geo::dist(box.getLowerLeft(), box.getUpperRight());
+        double diag = util::geo::dist(box.getLowerLeft(), box.getUpperRight());
         double searchRad =
             g.getMaxLineNum() * (_cfg->lineWidth + _cfg->lineSpacing) +
             std::max(_cfg->stationLabelSize, diag);
@@ -347,9 +350,8 @@ void Labeller::labelStations(const RenderGraph &g, bool notdeg2) {
                              ? kTerminusAnglePen
                              : 0;
         cands.emplace_back(PolyLine<double>(band[0]), band, fontSize,
-                           isTerminus, deg, offset, overlaps,
-                           sidePen + termPen, _cfg->stationLineOverlapPenalty,
-                           station);
+                           isTerminus, deg, offset, overlaps, sidePen + termPen,
+                           _cfg->stationLineOverlapPenalty, station);
       }
     }
 
@@ -476,7 +478,8 @@ void Labeller::labelLines(const RenderGraph &g) {
           // Reject candidates that bend too much.
           auto line = cand.getLine();
           double chord = util::geo::dist(line.front(), line.back());
-          if (chord > 0 && cand.getLength() / chord > _cfg->lineLabelLengthRatio) {
+          if (chord > 0 &&
+              cand.getLength() / chord > _cfg->lineLabelLengthRatio) {
             start += step;
             continue;
           }
@@ -492,12 +495,14 @@ void Labeller::labelLines(const RenderGraph &g) {
               double v2y = c.getY() - b.getY();
               double len1 = std::hypot(v1x, v1y);
               double len2 = std::hypot(v2x, v2y);
-              if (len1 == 0 || len2 == 0) continue;
+              if (len1 == 0 || len2 == 0)
+                continue;
               double cosTheta = (v1x * v2x + v1y * v2y) / (len1 * len2);
               cosTheta = std::max(-1.0, std::min(1.0, cosTheta));
               double theta = std::acos(cosTheta);
               double bend = M_PI - theta;
-              if (bend > maxBend) maxBend = bend;
+              if (bend > maxBend)
+                maxBend = bend;
             }
           }
           if (maxBend > _cfg->lineLabelBendAngle) {

--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -1136,8 +1136,10 @@ void SvgRenderer::renderStationLabels(const Labeller &labeller,
     params["font-weight"] = label.bold ? "bold" : "normal";
     params["font-family"] = "TT Norms Pro";
     params["dy"] = shift;
-    params["font-size"] =
-        util::toString(label.fontSize * _cfg->outputResolution);
+    double fontSize = label.fontSize * _cfg->outputResolution;
+    if (_cfg->fontSvgMax >= 0 && fontSize > _cfg->fontSvgMax)
+      fontSize = _cfg->fontSvgMax;
+    params["font-size"] = util::toString(fontSize);
 
     _w.openTag("text", params);
     _w.openTag("textPath", {{"dy", shift},


### PR DESCRIPTION
## Summary
- add `fontSvgMax` configuration with `--font-svg-max` CLI option
- clamp station label rendering to respect maximum SVG font size

## Testing
- `cmake ..` *(fails: The source directory /workspace/loom/src/util does not contain a CMakeLists.txt file)*
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae470b1da8832da467252f011ac479