### PR TITLE
Add --me option to mark user location

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ Command-line parameters
 * `--no-render-stations`: don't render stations.
 * `--no-render-node-connections`: don't render inner node connections.
 * `--render-node-fronts`: render node fronts.
+* `--me <lat,lon>`: mark the given coordinates with a red "YOU ARE HERE" star.
 * `--print-stats`: write statistics to stdout.
 * `-h`, `--help` and `-v`, `--version`.
 

--- a/src/transitmap/config/ConfigReader.cpp
+++ b/src/transitmap/config/ConfigReader.cpp
@@ -129,6 +129,8 @@ void ConfigReader::help(const char *bin) const {
             << std::setw(37) << "  --landmarks arg"
             << "read landmarks from file, one word:text,lat,lon[,size[,color]] "
                "or iconPath,lat,lon[,size] per line\n"
+            << std::setw(37) << "  --me arg"
+            << "mark current location lat,lon with YOU ARE HERE star\n"
             << std::setw(37) << "  --print-stats"
             << "write stats to stdout\n";
 }
@@ -179,6 +181,7 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
       {"print-stats", no_argument, 0, 19},
       {"landmark", required_argument, 0, 21},
       {"landmarks", required_argument, 0, 22},
+      {"me", required_argument, 0, 39},
       {0, 0, 0, 0}};
 
   std::string zoom;
@@ -406,6 +409,23 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
           exit(1);
         }
         cfg->landmarks.push_back(lm);
+      }
+      break;
+    }
+    case 39: {
+      auto parts = util::split(optarg, ',');
+      if (parts.size() == 2) {
+        double lat = atof(parts[0].c_str());
+        double lon = atof(parts[1].c_str());
+        cfg->renderMe = true;
+        cfg->meLandmark.label = "\u2605 YOU ARE HERE";
+        cfg->meLandmark.color = "#f00";
+        cfg->meLandmark.size = 80;
+        cfg->meLandmark.coord = util::geo::latLngToWebMerc<double>(lat, lon);
+      } else {
+        std::cerr << "Error while parsing me location " << optarg
+                  << " (expected lat,lon)" << std::endl;
+        exit(1);
       }
       break;
     }

--- a/src/transitmap/config/TransitMapConfig.h
+++ b/src/transitmap/config/TransitMapConfig.h
@@ -79,6 +79,9 @@ struct Config {
   std::string worldFilePath;
 
   std::vector<Landmark> landmarks;
+
+  bool renderMe = false;
+  Landmark meLandmark;
 };
 
 } // namespace config

--- a/src/transitmap/output/SvgRenderer.h
+++ b/src/transitmap/output/SvgRenderer.h
@@ -114,6 +114,9 @@ class SvgRenderer : public Renderer {
       const shared::rendergraph::RenderGraph& g,
       const std::vector<shared::rendergraph::Landmark>& landmarks,
       const RenderParams& params);
+  void renderMe(const shared::rendergraph::RenderGraph& g,
+                label::Labeller& labeller,
+                const RenderParams& params);
 
   void renderLineLabels(const label::Labeller& lbler,
                         const RenderParams& params);


### PR DESCRIPTION
## Summary
- add `--me` flag to transitmap to render a red "YOU ARE HERE" star near specified coordinates
- support placement without overlapping existing map features
- render user location after routes and stations for proper layering

## Testing
- `cmake ..` *(fails: The source directory /workspace/loom/src/util does not contain a CMakeLists.txt file)*

------
https://chatgpt.com/codex/tasks/task_e_68ae4ab9105c832da10f3acf6668de9e