### PR TITLE
Favor external station label placement

### DIFF
--- a/src/transitmap/label/Labeller.cpp
+++ b/src/transitmap/label/Labeller.cpp
@@ -309,6 +309,7 @@ void Labeller::labelStations(const RenderGraph &g, bool notdeg2) {
   orderedNds.reserve(termini.size() + others.size());
   orderedNds.insert(orderedNds.end(), termini.begin(), termini.end());
   orderedNds.insert(orderedNds.end(), others.begin(), others.end());
+  auto mapBox = g.getBBox();
 
   for (auto n : orderedNds) {
     double fontSize = _cfg->stationLabelSize;
@@ -366,6 +367,12 @@ void Labeller::labelStations(const RenderGraph &g, bool notdeg2) {
         double clusterPen =
             static_cast<double>(neighEdges.size() + neighNodes.size());
 
+        bool outside = box.getLowerLeft().getX() < mapBox.getLowerLeft().getX() ||
+                        box.getLowerLeft().getY() < mapBox.getLowerLeft().getY() ||
+                        box.getUpperRight().getX() > mapBox.getUpperRight().getX() ||
+                        box.getUpperRight().getY() > mapBox.getUpperRight().getY();
+        double outsidePen = outside ? -5.0 : 0.0;
+
         size_t diff = (deg + 12 - prefDeg) % 12;
         if (diff > 6)
           diff = 12 - diff;
@@ -375,7 +382,8 @@ void Labeller::labelStations(const RenderGraph &g, bool notdeg2) {
                              : 0;
         cands.emplace_back(PolyLine<double>(band[0]), band, fontSize,
                            isTerminus, deg, offset, overlaps, sidePen + termPen,
-                           _cfg->stationLineOverlapPenalty, clusterPen, station);
+                           _cfg->stationLineOverlapPenalty, clusterPen,
+                           outsidePen, station);
       }
     }
 

--- a/src/transitmap/label/Labeller.h
+++ b/src/transitmap/label/Labeller.h
@@ -66,6 +66,8 @@ struct StationLabel {
   double lineOverlapPenalty = 15;
   // penalty for placing labels in crowded regions
   double clusterPen = 0;
+  // bonus for placing labels outside of the map bounds
+  double outsidePen = 0;
 
   shared::linegraph::Station s;
 
@@ -73,7 +75,7 @@ struct StationLabel {
                const util::geo::MultiLine<double>& band, double fontSize,
                bool bold, size_t deg, size_t pos, const Overlaps& overlaps,
                double sidePen, double lineOverlapPenalty, double clusterPen,
-               const shared::linegraph::Station& s)
+               double outsidePen, const shared::linegraph::Station& s)
       : geom(geom),
         band(band),
         fontSize(fontSize),
@@ -84,6 +86,7 @@ struct StationLabel {
         sidePen(sidePen),
         lineOverlapPenalty(lineOverlapPenalty),
         clusterPen(clusterPen),
+        outsidePen(outsidePen),
         s(s) {}
 
   double getPen() const {
@@ -97,6 +100,7 @@ struct StationLabel {
     score += DEG_PENS[deg % DEG_PENS.size()];
     score += sidePen;
     score += clusterPen;
+    score += outsidePen;
 
     if (pos == 0) score += 0.5;
     if (pos == 2) score += 0.1;


### PR DESCRIPTION
## Summary
- derive overall map bounding box once before labeling stations
- encourage placing station labels outside map bounds via new `outsidePen`
- include outside placement bonus in station label penalty calculation

## Testing
- `pytest`
- `cmake -S . -B build` *(fails: src/util missing CMakeLists.txt)*

------
https://chatgpt.com/codex/tasks/task_e_68ae59cc75d4832d89e41f769ad03843