### PR TITLE
Add configurable me marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,9 @@ Command-line parameters
 * `--no-render-stations`: don't render stations.
 * `--no-render-node-connections`: don't render inner node connections.
 * `--render-node-fronts`: render node fronts.
-* `--me <lat,lon>`: mark the given coordinates with a red "YOU ARE HERE" star.
+* `--me <lat,lon>`: mark the given coordinates with a red star.
+* `--me-size <size>`: star size (default `150`).
+* `--me-label`: add a "YOU ARE HERE" label.
 * `--print-stats`: write statistics to stdout.
 * `-h`, `--help` and `-v`, `--version`.
 

--- a/src/transitmap/config/ConfigReader.cpp
+++ b/src/transitmap/config/ConfigReader.cpp
@@ -132,7 +132,11 @@ void ConfigReader::help(const char *bin) const {
             << "read landmarks from file, one word:text,lat,lon[,size[,color]] "
                "or iconPath,lat,lon[,size] per line\n"
             << std::setw(37) << "  --me arg"
-            << "mark current location lat,lon with YOU ARE HERE star\n"
+            << "mark current location lat,lon with star\n"
+            << std::setw(37) << "  --me-size arg (=150)"
+            << "size of 'me' star\n"
+            << std::setw(37) << "  --me-label"
+            << "add 'YOU ARE HERE' text\n"
             << std::setw(37) << "  --print-stats"
             << "write stats to stdout\n";
 }
@@ -184,6 +188,8 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
       {"print-stats", no_argument, 0, 19},
       {"landmark", required_argument, 0, 21},
       {"landmarks", required_argument, 0, 22},
+      {"me-size", required_argument, 0, 41},
+      {"me-label", no_argument, 0, 42},
       {"me", required_argument, 0, 39},
       {0, 0, 0, 0}};
 
@@ -224,6 +230,7 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
       break;
     case 40:
       cfg->meLabelSize = atof(optarg);
+      cfg->meLandmark.size = cfg->meLabelSize;
       break;
     case 38:
       cfg->fontSvgMax = atof(optarg);
@@ -424,10 +431,11 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
         double lat = atof(parts[0].c_str());
         double lon = atof(parts[1].c_str());
         cfg->renderMe = true;
-        cfg->meLandmark.label = "YOU ARE HERE";
         cfg->meLandmark.color = "#f00";
         cfg->meLandmark.size = cfg->meLabelSize;
         cfg->meLandmark.coord = util::geo::latLngToWebMerc<double>(lat, lon);
+        if (cfg->renderMeLabel)
+          cfg->meLandmark.label = "YOU ARE HERE";
       } else {
         std::cerr << "Error while parsing me location " << optarg
                   << " (expected lat,lon)" << std::endl;
@@ -435,6 +443,14 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
       }
       break;
     }
+    case 41:
+      cfg->meStarSize = atof(optarg);
+      break;
+    case 42:
+      cfg->renderMeLabel = true;
+      cfg->meLandmark.label = "YOU ARE HERE";
+      cfg->meLandmark.size = cfg->meLabelSize;
+      break;
     case 'D':
       cfg->fromDot = true;
       break;

--- a/src/transitmap/config/TransitMapConfig.h
+++ b/src/transitmap/config/TransitMapConfig.h
@@ -24,8 +24,10 @@ struct Config {
   // Maximum allowed ratio of polyline length to straight-line distance.
   double lineLabelLengthRatio = 1.1;
   double stationLabelSize = 60;
-  // Text size for the "YOU ARE HERE" marker.
+  // Text size for the optional "YOU ARE HERE" label.
   double meLabelSize = 80;
+  // Size of the star marker for --me.
+  double meStarSize = 150;
   double stationLineOverlapPenalty = 15;
   // Maximum font size for station labels in SVG output; -1 for no limit.
   double fontSvgMax = 11;
@@ -83,6 +85,7 @@ struct Config {
   std::vector<Landmark> landmarks;
 
   bool renderMe = false;
+  bool renderMeLabel = false;
   Landmark meLandmark;
 };
 


### PR DESCRIPTION
## Summary
- Allow marking current location with a red star via `--me` with configurable size
- Support optional `YOU ARE HERE` text via `--me-label`
- Document new `--me-size` and `--me-label` flags

## Testing
- `cmake ..` *(fails: The source directory /workspace/loom/src/util does not contain a CMakeLists.txt file)*
- `git submodule update --init --recursive` *(fails: unable to access submodule repositories)*

------
https://chatgpt.com/codex/tasks/task_e_68ae69219578832dbdb801aff9f3a5f2