### PR TITLE
Fix landmark parsing for landmarks and icon paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,9 +250,11 @@ Each landmark line is either
 
 * `word:<text>,lat,lon[,size[,color]]` – render the given text at the
   geographic position. The optional `size` defaults to `200` and `color` to
-  `#000`.
+  `#000`. If you want to specify only a color, omit the size, e.g.
+  `word:CityHall,47.92,106.91,#ff0000`.
 * `iconPath,lat,lon[,size]` – place an SVG icon from `iconPath`. The optional
-  `size` also defaults to `200`.
+  `size` also defaults to `200`. Relative `iconPath` values are resolved
+  relative to the landmarks file.
 
 Landmarks that would overlap with existing labels, map features, or previously
 placed landmarks are skipped. To render the sample landmarks alongside a map,


### PR DESCRIPTION
## Summary
- Permit specifying landmark color without size and resolve icon paths relative to landmarks file
- Document color-only landmarks and file-relative icon paths

## Testing
- `cmake -S . -B build` *(fails: source directory missing CMakeLists due to absent submodules)*
- `git submodule update --init --recursive` *(fails: access to submodules denied)*

------
https://chatgpt.com/codex/tasks/task_e_68ae6b155c4c832db8cd4fb6cf7f9a48