### PR TITLE
feat: customizable 'me' station marker

### DIFF
--- a/src/transitmap/TransitMapMain.cpp
+++ b/src/transitmap/TransitMapMain.cpp
@@ -16,6 +16,7 @@
 #include "transitmap/graph/GraphBuilder.h"
 #include "transitmap/output/MvtRenderer.h"
 #include "transitmap/output/SvgRenderer.h"
+#include "util/String.h"
 #include "util/log/Log.h"
 
 using shared::linegraph::LineGraph;
@@ -81,6 +82,19 @@ int main(int argc, char **argv) {
         g.createMetaNodes();
       }
 
+      if (!cfg.meStation.empty()) {
+        for (auto n : g.getNds()) {
+          if (!n->pl().stops().size()) continue;
+          const auto &st = n->pl().stops().front();
+          if (util::sanitizeStationLabel(st.name) == cfg.meStation) {
+            cfg.meLandmark.coord = st.pos;
+            cfg.meLandmark.color = cfg.meStationFill;
+            cfg.renderMe = true;
+            break;
+          }
+        }
+      }
+
       LOGTO(DEBUG, std::cerr) << "Outputting to MVT ...";
       transitmapper::output::MvtRenderer mvtOut(&cfg, z);
       mvtOut.print(g);
@@ -115,6 +129,19 @@ int main(int argc, char **argv) {
       g.contractStrayNds();
       b.expandOverlappinFronts(&g);
       g.createMetaNodes();
+    }
+
+    if (!cfg.meStation.empty()) {
+      for (auto n : g.getNds()) {
+        if (!n->pl().stops().size()) continue;
+        const auto &st = n->pl().stops().front();
+        if (util::sanitizeStationLabel(st.name) == cfg.meStation) {
+          cfg.meLandmark.coord = st.pos;
+          cfg.meLandmark.color = cfg.meStationFill;
+          cfg.renderMe = true;
+          break;
+        }
+      }
     }
 
     // Attach landmarks.

--- a/src/transitmap/config/ConfigReader.cpp
+++ b/src/transitmap/config/ConfigReader.cpp
@@ -165,6 +165,12 @@ void ConfigReader::help(const char *bin) const {
             << "size of 'me' star\n"
             << std::setw(37) << "  --me-label"
             << "add 'YOU ARE HERE' text\n"
+            << std::setw(37) << "  --me-station arg"
+            << "mark current location by station label\n"
+            << std::setw(37) << "  --me-station-fill arg (=#f00)"
+            << "fill color for 'me' marker\n"
+            << std::setw(37) << "  --me-station-border arg"
+            << "border color for 'me' marker\n"
             << std::setw(37) << "  --print-stats"
             << "write stats to stdout\n";
 }
@@ -219,6 +225,9 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
       {"me-size", required_argument, 0, 41},
       {"me-label", no_argument, 0, 42},
       {"me", required_argument, 0, 39},
+      {"me-station", required_argument, 0, 43},
+      {"me-station-fill", required_argument, 0, 44},
+      {"me-station-border", required_argument, 0, 45},
       {0, 0, 0, 0}};
 
   std::string zoom;
@@ -480,7 +489,7 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
         double lat = atof(parts[0].c_str());
         double lon = atof(parts[1].c_str());
         cfg->renderMe = true;
-        cfg->meLandmark.color = "#f00";
+      cfg->meLandmark.color = cfg->meStationFill;
         cfg->meLandmark.size = cfg->meLabelSize;
         cfg->meLandmark.coord = util::geo::latLngToWebMerc<double>(lat, lon);
         if (cfg->renderMeLabel)
@@ -499,6 +508,16 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
       cfg->renderMeLabel = true;
       cfg->meLandmark.label = "YOU ARE HERE";
       cfg->meLandmark.size = cfg->meLabelSize;
+      break;
+    case 43:
+      cfg->meStation = util::sanitizeStationLabel(optarg);
+      break;
+    case 44:
+      cfg->meStationFill = optarg;
+      cfg->meLandmark.color = cfg->meStationFill;
+      break;
+    case 45:
+      cfg->meStationBorder = optarg;
       break;
     case 'D':
       cfg->fromDot = true;

--- a/src/transitmap/config/TransitMapConfig.h
+++ b/src/transitmap/config/TransitMapConfig.h
@@ -84,6 +84,10 @@ struct Config {
 
   std::vector<Landmark> landmarks;
 
+  std::string meStation;
+  std::string meStationFill = "#f00";
+  std::string meStationBorder;
+
   bool renderMe = false;
   bool renderMeLabel = false;
   Landmark meLandmark;

--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -685,7 +685,8 @@ void SvgRenderer::renderMe(const RenderGraph &g, Labeller &labeller,
   }
   std::map<std::string, std::string> attrs;
   attrs["points"] = starPts.str();
-  attrs["fill"] = "#f00";
+  attrs["fill"] = _cfg->meStationFill;
+  attrs["stroke"] = _cfg->meStationBorder;
   _w.openTag("polygon", attrs);
   _w.closeTag();
 
@@ -695,7 +696,7 @@ void SvgRenderer::renderMe(const RenderGraph &g, Labeller &labeller,
     params["y"] = util::toString(y);
     params["font-size"] = util::toString(labelSize);
     params["text-anchor"] = "middle";
-    params["fill"] = lm.color;
+    params["fill"] = _cfg->meStationFill;
     params["font-family"] = "TT Norms Pro";
 
     _w.openTag("text", params);

--- a/src/util/String.h
+++ b/src/util/String.h
@@ -1,0 +1,72 @@
+// Utility string functions for LOOM.
+// Provides basic helpers including station label sanitization.
+
+#ifndef UTIL_STRING_H_
+#define UTIL_STRING_H_
+
+#include <algorithm>
+#include <codecvt>
+#include <locale>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace util {
+
+inline std::vector<std::string> split(const std::string &s, char delim) {
+  std::vector<std::string> elems;
+  std::string item;
+  std::stringstream ss(s);
+  while (std::getline(ss, item, delim)) {
+    elems.push_back(item);
+  }
+  return elems;
+}
+
+inline void replaceAll(std::string &str, const std::string &from,
+                       const std::string &to) {
+  if (from.empty()) return;
+  size_t start = 0;
+  while ((start = str.find(from, start)) != std::string::npos) {
+    str.replace(start, from.length(), to);
+    start += to.length();
+  }
+}
+
+inline std::string trimCopy(const std::string &s) {
+  const std::string WHITESPACE = " \n\r\t";
+  auto start = s.find_first_not_of(WHITESPACE);
+  if (start == std::string::npos) return "";
+  auto end = s.find_last_not_of(WHITESPACE);
+  return s.substr(start, end - start + 1);
+}
+
+inline std::string toString(double d) {
+  std::ostringstream oss;
+  oss << d;
+  return oss.str();
+}
+
+inline std::string sanitizeStationLabel(const std::string &in) {
+  std::wstring_convert<std::codecvt_utf8<wchar_t>> conv;
+  std::wstring ws = conv.from_bytes(in);
+  std::wstring out;
+  bool prevUnderscore = false;
+  std::locale loc;
+  for (wchar_t c : ws) {
+    if (std::iswalnum(c, loc)) {
+      out.push_back(c);
+      prevUnderscore = false;
+    } else if (!prevUnderscore) {
+      out.push_back(L'_');
+      prevUnderscore = true;
+    }
+  }
+  while (!out.empty() && out.front() == L'_') out.erase(out.begin());
+  while (!out.empty() && out.back() == L'_') out.pop_back();
+  return conv.to_bytes(out);
+}
+
+}  // namespace util
+
+#endif  // UTIL_STRING_H_


### PR DESCRIPTION
## Summary
- add configuration fields and CLI options for marking a "me" station
- sanitize station labels for matching
- use configurable fill/border colors and resolve coordinates by station name

## Testing
- `cmake ..` *(fails: The source directory /workspace/loom/src/util does not contain a CMakeLists.txt file)*

------
https://chatgpt.com/codex/tasks/task_e_68b14771b3fc832d8e40ec1d7ea7f547