### PR TITLE
feat: customizable 'me' station marker

### DIFF
--- a/src/transitmap/TransitMapMain.cpp
+++ b/src/transitmap/TransitMapMain.cpp
@@ -16,6 +16,7 @@
 #include "transitmap/graph/GraphBuilder.h"
 #include "transitmap/output/MvtRenderer.h"
 #include "transitmap/output/SvgRenderer.h"
+#include "transitmap/util/String.h"
 #include "util/log/Log.h"
 
 using shared::linegraph::LineGraph;
@@ -81,6 +82,19 @@ int main(int argc, char **argv) {
         g.createMetaNodes();
       }
 
+      if (!cfg.meStation.empty()) {
+        for (auto n : g.getNds()) {
+          if (!n->pl().stops().size()) continue;
+          const auto &st = n->pl().stops().front();
+          if (util::sanitizeStationLabel(st.name) == cfg.meStation) {
+            cfg.meLandmark.coord = st.pos;
+            cfg.meLandmark.color = cfg.meStationFill;
+            cfg.renderMe = true;
+            break;
+          }
+        }
+      }
+
       LOGTO(DEBUG, std::cerr) << "Outputting to MVT ...";
       transitmapper::output::MvtRenderer mvtOut(&cfg, z);
       mvtOut.print(g);
@@ -115,6 +129,19 @@ int main(int argc, char **argv) {
       g.contractStrayNds();
       b.expandOverlappinFronts(&g);
       g.createMetaNodes();
+    }
+
+    if (!cfg.meStation.empty()) {
+      for (auto n : g.getNds()) {
+        if (!n->pl().stops().size()) continue;
+        const auto &st = n->pl().stops().front();
+        if (util::sanitizeStationLabel(st.name) == cfg.meStation) {
+          cfg.meLandmark.coord = st.pos;
+          cfg.meLandmark.color = cfg.meStationFill;
+          cfg.renderMe = true;
+          break;
+        }
+      }
     }
 
     // Attach landmarks.

--- a/src/transitmap/config/ConfigReader.cpp
+++ b/src/transitmap/config/ConfigReader.cpp
@@ -13,7 +13,7 @@
 #include "shared/rendergraph/Landmark.h"
 #include "transitmap/_config.h"
 #include "transitmap/config/ConfigReader.h"
-#include "util/String.h"
+#include "transitmap/util/String.h"
 #include "util/geo/Geo.h"
 #include "util/log/Log.h"
 
@@ -165,6 +165,12 @@ void ConfigReader::help(const char *bin) const {
             << "size of 'me' star\n"
             << std::setw(37) << "  --me-label"
             << "add 'YOU ARE HERE' text\n"
+            << std::setw(37) << "  --me-station arg"
+            << "mark current location by station label\n"
+            << std::setw(37) << "  --me-station-fill arg (=#f00)"
+            << "fill color for 'me' marker\n"
+            << std::setw(37) << "  --me-station-border arg"
+            << "border color for 'me' marker\n"
             << std::setw(37) << "  --print-stats"
             << "write stats to stdout\n";
 }
@@ -219,6 +225,9 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
       {"me-size", required_argument, 0, 41},
       {"me-label", no_argument, 0, 42},
       {"me", required_argument, 0, 39},
+      {"me-station", required_argument, 0, 43},
+      {"me-station-fill", required_argument, 0, 44},
+      {"me-station-border", required_argument, 0, 45},
       {0, 0, 0, 0}};
 
   std::string zoom;
@@ -480,7 +489,7 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
         double lat = atof(parts[0].c_str());
         double lon = atof(parts[1].c_str());
         cfg->renderMe = true;
-        cfg->meLandmark.color = "#f00";
+      cfg->meLandmark.color = cfg->meStationFill;
         cfg->meLandmark.size = cfg->meLabelSize;
         cfg->meLandmark.coord = util::geo::latLngToWebMerc<double>(lat, lon);
         if (cfg->renderMeLabel)
@@ -499,6 +508,16 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
       cfg->renderMeLabel = true;
       cfg->meLandmark.label = "YOU ARE HERE";
       cfg->meLandmark.size = cfg->meLabelSize;
+      break;
+    case 43:
+      cfg->meStation = util::sanitizeStationLabel(optarg);
+      break;
+    case 44:
+      cfg->meStationFill = optarg;
+      cfg->meLandmark.color = cfg->meStationFill;
+      break;
+    case 45:
+      cfg->meStationBorder = optarg;
       break;
     case 'D':
       cfg->fromDot = true;

--- a/src/transitmap/config/TransitMapConfig.h
+++ b/src/transitmap/config/TransitMapConfig.h
@@ -84,6 +84,10 @@ struct Config {
 
   std::vector<Landmark> landmarks;
 
+  std::string meStation;
+  std::string meStationFill = "#f00";
+  std::string meStationBorder;
+
   bool renderMe = false;
   bool renderMeLabel = false;
   Landmark meLandmark;

--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -685,7 +685,8 @@ void SvgRenderer::renderMe(const RenderGraph &g, Labeller &labeller,
   }
   std::map<std::string, std::string> attrs;
   attrs["points"] = starPts.str();
-  attrs["fill"] = "#f00";
+  attrs["fill"] = _cfg->meStationFill;
+  attrs["stroke"] = _cfg->meStationBorder;
   _w.openTag("polygon", attrs);
   _w.closeTag();
 
@@ -695,7 +696,7 @@ void SvgRenderer::renderMe(const RenderGraph &g, Labeller &labeller,
     params["y"] = util::toString(y);
     params["font-size"] = util::toString(labelSize);
     params["text-anchor"] = "middle";
-    params["fill"] = lm.color;
+    params["fill"] = _cfg->meStationFill;
     params["font-family"] = "TT Norms Pro";
 
     _w.openTag("text", params);

--- a/src/transitmap/util/String.h
+++ b/src/transitmap/util/String.h
@@ -1,0 +1,33 @@
+#ifndef TRANSITMAP_UTIL_STRING_H_
+#define TRANSITMAP_UTIL_STRING_H_
+
+#include <codecvt>
+#include <cwctype>
+#include <locale>
+#include <string>
+
+namespace util {
+
+inline std::string sanitizeStationLabel(const std::string& input) {
+  std::wstring_convert<std::codecvt_utf8<wchar_t>> conv;
+  std::wstring ws = conv.from_bytes(input);
+  std::wstring out;
+  bool prevUnderscore = false;
+  std::locale loc;
+  for (wchar_t c : ws) {
+    if (std::iswalnum(c, loc)) {
+      out.push_back(c);
+      prevUnderscore = false;
+    } else if (!prevUnderscore) {
+      out.push_back(L'_');
+      prevUnderscore = true;
+    }
+  }
+  while (!out.empty() && out.front() == L'_') out.erase(out.begin());
+  while (!out.empty() && out.back() == L'_') out.pop_back();
+  return conv.to_bytes(out);
+}
+
+}  // namespace util
+
+#endif  // TRANSITMAP_UTIL_STRING_H_


### PR DESCRIPTION
## Summary
- add configuration fields and CLI options for marking a "me" station
- sanitize station labels and resolve coordinates to highlight a "me" location
- use configurable fill/border colors for the "me" marker and its label

## Testing
- `git submodule update --init` *(fails: unable to access submodules, CONNECT tunnel failed)*
- `cmake ..` *(fails: source directories `src/util` and `src/cppgtfs` lack CMakeLists.txt)*

------
https://chatgpt.com/codex/tasks/task_e_68b14771b3fc832d8e40ec1d7ea7f547