### PR TITLE
Queue all landmarks for SvgRenderer output

### DIFF
--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -179,9 +179,8 @@ void SvgRenderer::print(const RenderGraph &outG) {
     util::geo::Box<double> lmBox(
         DPoint(lm.coord.getX() - halfW, lm.coord.getY() - halfH),
         DPoint(lm.coord.getX() + halfW, lm.coord.getY() + halfH));
-    if (labeller.addLandmark(lmBox)) {
-      acceptedLandmarks.push_back(lm);
-    }
+    labeller.addLandmark(lmBox);   // optional, for label collision tracking
+    acceptedLandmarks.push_back(lm);
   }
   if (_cfg->renderMe) {
     double starPx = _cfg->meStarSize * _cfg->outputResolution;


### PR DESCRIPTION
## Summary
- queue every landmark for rendering in SvgRenderer::print
- retain later bounding-box filter for out-of-bounds landmarks

## Testing
- `cmake -S . -B build` *(fails: source directories lack CMakeLists.txt; missing submodules)*
- `git submodule update --init --recursive` *(fails: unable to clone due to 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b150a62298832dad7d325825b7f070