### PR TITLE
Allow specifying config file via --config

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,8 @@ Configuration
 
 All tools consult optional `.loom.ini` files for default settings. First
 `$HOME/.loom.ini` is loaded, then a `.loom.ini` located next to the running
-binary, and finally any command-line flags. Later sources override earlier
+binary, and finally any command-line flags. You can also specify an explicit
+configuration file with `--config=<file>`. Later sources override earlier
 ones. See the provided [loom.ini](loom.ini) for supported keys and default
 values.
 


### PR DESCRIPTION
## Summary
- enable `--config=<file>` flag in `transitmap` to load settings from an explicit config file before other options
- document `--config` usage in help text and README

## Testing
- ⚠️ `cmake -S . -B build` *(failed: repository submodule could not be cloned)*


------
https://chatgpt.com/codex/tasks/task_e_68b165521484832d9857d52ef11de325