### PR TITLE
Adjust terminus label box width based on label text

### DIFF
--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -1646,7 +1646,6 @@ void SvgRenderer::renderTerminusLabels(const RenderGraph &g,
     double pad = fontSize * 0.2;
     double boxH = fontSize + pad * 2;
     double charW = fontSize * 0.6;
-    double boxW = 5 * charW + pad * 2; // uniform width for up to 4 chars
     double boxR = pad * 2;
 
     size_t idx = 0;
@@ -1660,6 +1659,8 @@ void SvgRenderer::renderTerminusLabels(const RenderGraph &g,
 
     for (auto line : lines) {
       std::string label = line->label();
+      double labelWidth = label.size() * charW;
+      double boxW = labelWidth + pad * 2;
       double rectX = x - boxW / 2;
       double rectY = above ? startY - idx * step : startY + idx * step;
 


### PR DESCRIPTION
## Summary
- Compute terminus label box width dynamically from the actual label text
- Position terminus label boxes using the calculated width so longer labels are fully visible

## Testing
- `cmake ..` *(fails: source directory src/cppgtfs missing; submodule clone blocked)*
- `transitmap -h` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b556adfaa4832d94f2f6d0bd36f68b