### PR TITLE
Disable tails when dir markers triggered by sharp angles

### DIFF
--- a/src/transitmap/output/SvgRenderer.h
+++ b/src/transitmap/output/SvgRenderer.h
@@ -81,6 +81,10 @@ class SvgRenderer : public Renderer {
                       const util::geo::PolyLine<double>& center,
                       const shared::linegraph::Line* line);
 
+  bool hasSharpAngle(const shared::linegraph::LineEdge* e,
+                     const util::geo::PolyLine<double>& center,
+                     const shared::linegraph::Line* line);
+
   void renderNodeConnections(const shared::rendergraph::RenderGraph& outG,
                              const shared::linegraph::LineNode* n,
                              const RenderParams& params);


### PR DESCRIPTION
## Summary
- avoid drawing marker tails on edges that are too short or have sharp turns
- add helper to detect sharp angles in edge geometry

## Testing
- `cmake -S . -B build` (fails: The source directory /workspace/loom/src/cppgtfs does not contain a CMakeLists.txt file)
- `git submodule update --init --recursive` (fails: fatal: unable to access 'https://github.com/ad-freiburg/cppgtfs.git/': CONNECT tunnel failed, response 403)


------
https://chatgpt.com/codex/tasks/task_e_68b55a58a144832db306d22b43c0eaa7