### PR TITLE
Clean up ConfigReader includes and helpers

### DIFF
--- a/src/gtfs2graph/config/ConfigReader.cpp
+++ b/src/gtfs2graph/config/ConfigReader.cpp
@@ -2,10 +2,7 @@
 // Chair of Algorithms and Data Structures.
 // Authors: Patrick Brosi <brosi@informatik.uni-freiburg.de>
 
-#include <float.h>
 #include <getopt.h>
-
-#include <exception>
 #include <iostream>
 #include <string>
 
@@ -17,7 +14,6 @@
 
 using gtfs2graph::config::ConfigReader;
 
-using std::exception;
 using std::string;
 using std::vector;
 

--- a/src/loom/config/ConfigReader.cpp
+++ b/src/loom/config/ConfigReader.cpp
@@ -2,9 +2,7 @@
 // Chair of Algorithms and Data Structures.
 // Authors: Patrick Brosi <brosi@informatik.uni-freiburg.de>
 
-#include <float.h>
 #include <getopt.h>
-#include <exception>
 #include <iostream>
 #include <string>
 #include "loom/_config.h"
@@ -14,7 +12,6 @@
 
 using loom::config::ConfigReader;
 
-using std::exception;
 using std::string;
 using std::vector;
 

--- a/src/octi/config/ConfigReader.cpp
+++ b/src/octi/config/ConfigReader.cpp
@@ -3,10 +3,7 @@
 // Chair of Algorithms and Data Structures.
 // Authors: Patrick Brosi <brosi@informatik.uni-freiburg.de>
 
-#include <float.h>
 #include <getopt.h>
-
-#include <exception>
 #include <iostream>
 #include <string>
 
@@ -18,7 +15,6 @@ using octi::config::ConfigReader;
 
 using octi::basegraph::BaseGraphType;
 using octi::config::OrderMethod;
-using std::exception;
 using std::string;
 using std::vector;
 

--- a/src/topo/config/ConfigReader.cpp
+++ b/src/topo/config/ConfigReader.cpp
@@ -2,10 +2,7 @@
 // Chair of Algorithms and Data Structures.
 // Authors: Patrick Brosi <brosi@informatik.uni-freiburg.de>
 
-#include <float.h>
 #include <getopt.h>
-
-#include <exception>
 #include <iostream>
 #include <string>
 
@@ -15,7 +12,6 @@
 
 using topo::config::ConfigReader;
 
-using std::exception;
 using std::string;
 using std::vector;
 

--- a/src/transitmap/config/ConfigReader.cpp
+++ b/src/transitmap/config/ConfigReader.cpp
@@ -2,10 +2,7 @@
 // Chair of Algorithms and Data Structures.
 // Authors: Patrick Brosi <brosi@informatik.uni-freiburg.de>
 
-#include <float.h>
 #include <getopt.h>
-
-#include <exception>
 #include <fstream>
 #include <limits.h>
 #ifndef _WIN32
@@ -28,7 +25,6 @@
 #include "util/log/Log.h"
 
 using shared::rendergraph::Landmark;
-using std::exception;
 using transitmapper::config::ConfigReader;
 using transitmapper::config::Config;
 
@@ -40,14 +36,6 @@ std::string dirName(const std::string& path) {
   size_t pos = path.find_last_of("/\\");
   if (pos == std::string::npos) return ".";
   return path.substr(0, pos);
-}
-
-// Check whether the given path is relative. Treat paths beginning with '/' or
-// '\\' or a Windows drive specification as absolute.
-bool isRelativePath(const std::string& path) {
-  if (path.empty()) return true;
-  if (path[0] == '/' || path[0] == '\\') return false;
-  return !(path.size() > 1 && path[1] == ':');
 }
 
 // Join two paths using '/' as separator if necessary.


### PR DESCRIPTION
## Summary
- Drop unused `<float.h>` includes and redundant `std::exception` aliases from various ConfigReaders
- Remove dead `isRelativePath` helper from TransitMap ConfigReader

## Testing
- `cmake -S . -B build` *(failed: missing submodule src/cppgtfs)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b1edc5c8832d8d3fac3384cd5ecb