### PR TITLE
Remove unused headers in GraphBuilder

### DIFF
--- a/src/transitmap/graph/GraphBuilder.cpp
+++ b/src/transitmap/graph/GraphBuilder.cpp
@@ -2,9 +2,7 @@
 // Chair of Algorithms and Data Structures.
 // Authors: Patrick Brosi <brosi@informatik.uni-freiburg.de>
 
-#include <istream>
 #include <set>
-#include <stack>
 #include <vector>
 
 #include "GraphBuilder.h"
@@ -148,40 +146,6 @@ void GraphBuilder::expandOverlappinFronts(RenderGraph* g) {
     if (!stillFree) break;
   }
 
-  // for (auto n : g->getNds()) {
-    // std::vector<util::geo::DLine> lines;
-    // for (size_t i = 0; i < n->pl().fronts().size(); ++i) {
-      // const NodeFront& f = n->pl().fronts()[i];
-      // lines.push_back(f.geom.getLine());
-    // }
-
-    // auto hull = util::geo::convexHull(lines);
-
-    // for (size_t i = 0; i < n->pl().fronts().size(); ++i) {
-      // NodeFront& f = n->pl().fronts()[i];
-
-      // auto isects = PolyLine<double>(*f.edge->pl().getGeom()).getIntersections(hull.getOuter());
-
-      // if (isects.size() == 0) continue;
-
-      // if (f.edge->getTo() == n) {
-        // f.geom = PolyLine<double>(*f.edge->pl().getGeom())
-                      // .getOrthoLineAt(isects.rbegin()->totalPos, g->getTotalWidth(f.edge));
-
-        // f.edge->pl().setGeom(PolyLine<double>(*f.edge->pl().getGeom())
-                                  // .getSegment(0, isects.rbegin()->totalPos)
-                                  // .getLine());
-      // } else {
-        // f.geom = PolyLine<double>(*f.edge->pl().getGeom())
-                      // .getOrthoLineAt(isects.begin()->totalPos, g->getTotalWidth(f.edge));
-
-        // f.edge->pl().setGeom(PolyLine<double>(*f.edge->pl().getGeom())
-                                  // .getSegment(isects.begin()->totalPos, 1)
-                                  // .getLine());
-        // f.geom.reverse();
-      // }
-    // }
-  // }
 }
 
 // _____________________________________________________________________________


### PR DESCRIPTION
## Summary
- Drop unused `<istream>` and `<stack>` includes from `GraphBuilder.cpp`
- Remove obsolete commented-out code in `expandOverlappinFronts`

## Testing
- `cmake -S . -B build` *(fails: The source directory `/workspace/loom/src/cppgtfs` does not contain a CMakeLists.txt file.)*
- `cmake -S src/transitmap -B build/transitmap` *(passes)*
- `cmake --build build/transitmap` *(fails: No rule to make target `/workspace/loom/src/transitmap/data/fonts/TT Norms Pro Regular.otf`)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b1f2b600832d9c2d3800d14b7a18