### PR TITLE
Guard unistd include for Windows build

### DIFF
--- a/src/transitmap/TransitMapMain.cpp
+++ b/src/transitmap/TransitMapMain.cpp
@@ -3,7 +3,9 @@
 // Author: Patrick Brosi
 
 #include <stdio.h>
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 
 #include <iostream>
 #include <string>


### PR DESCRIPTION
## Summary
- Guard `unistd.h` include behind `_WIN32` check in TransitMapMain to prevent build errors on non-POSIX platforms

## Testing
- `cmake -S . -B build` *(fails: /workspace/loom/src/cppgtfs does not contain a CMakeLists.txt file)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b2893e6c832da248dabdded16f73