### PR TITLE
Optimize SVG sanitization regex usage

### DIFF
--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -78,30 +78,21 @@ bool sanitizeSvg(std::string &s) {
     unsafe = true;
   }
 
-  if (std::regex_search(s, scriptRe)) {
-    s = std::regex_replace(s, scriptRe, "");
-    unsafe = true;
-  }
-  if (std::regex_search(s, onAttrRe)) {
-    s = std::regex_replace(s, onAttrRe, " ");
-    unsafe = true;
-  }
-  if (std::regex_search(s, jsHrefRe)) {
-    s = std::regex_replace(s, jsHrefRe, "");
-    unsafe = true;
-  }
-  if (std::regex_search(s, styleTagRe)) {
-    s = std::regex_replace(s, styleTagRe, "");
-    unsafe = true;
-  }
-  if (std::regex_search(s, styleAttrRe)) {
-    s = std::regex_replace(s, styleAttrRe, " ");
-    unsafe = true;
-  }
-  if (std::regex_search(s, dataUriAttrRe)) {
-    s = std::regex_replace(s, dataUriAttrRe, " ");
-    unsafe = true;
-  }
+  auto replaceAndCheck = [&s, &unsafe](const std::regex &re,
+                                      const std::string &rep) {
+    std::string replaced = std::regex_replace(s, re, rep);
+    if (replaced != s) {
+      s = std::move(replaced);
+      unsafe = true;
+    }
+  };
+
+  replaceAndCheck(scriptRe, "");
+  replaceAndCheck(onAttrRe, " ");
+  replaceAndCheck(jsHrefRe, "");
+  replaceAndCheck(styleTagRe, "");
+  replaceAndCheck(styleAttrRe, " ");
+  replaceAndCheck(dataUriAttrRe, " ");
 
   return unsafe;
 }


### PR DESCRIPTION
## Summary
- Avoid redundant regex scans in SVG sanitizer by replacing pairs of `regex_search`/`regex_replace` with a helper using a single `regex_replace`.

## Testing
- `cmake -S . -B build` *(fails: The source directory `/workspace/loom/src/cppgtfs` does not contain a CMakeLists.txt file)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b2f1f280832d87083b814fd8a011