### PR TITLE
Validate sharp-turn-angle option

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Command-line parameters
 * `--render-dir-markers` and `--render-markers-tail`: render line direction markers and tails.
 * `--bi-dir-marker`: render markers for bidirectional edges (default off).
 * `--crowded-line-thresh <n>`: lines on edge to trigger direction marker (default `3`).
-* `--sharp-turn-angle <rad>`: turn angle in radians to trigger direction marker (default `0.785398`).
+* `--sharp-turn-angle <rad>`: turn angle in radians (0-π) to trigger direction marker (default `0.785398`). Values >π are treated as degrees.
 * `-l`, `--labels`: render labels.
 * `-r`, `--route-labels`: render route names at line termini.
 * `--line-label-textsize <size>`: text size for line labels (default `40`).

--- a/loom.ini
+++ b/loom.ini
@@ -18,6 +18,7 @@ landmarks=../examples/landmark.txt
 # bi-dir-marker=false
 # crowded-line-thresh=3
 # sharp-turn-angle=0.785398
+#   angle in radians (0-PI); values >PI treated as degrees
 # labels=false
 # route-labels=false
 # line-label-textsize=40

--- a/src/transitmap/config/ConfigReader.cpp
+++ b/src/transitmap/config/ConfigReader.cpp
@@ -12,6 +12,7 @@
 #include <string>
 #include <unordered_map>
 #include <cstdlib>
+#include <cmath>
 #ifdef _WIN32
 #include <windows.h>
 #endif
@@ -151,9 +152,19 @@ void applyOption(Config* cfg, int c, const std::string& arg,
   case 28:
     cfg->crowdedLineThresh = atoi(arg.c_str());
     break;
-  case 29:
-    cfg->sharpTurnAngle = atof(arg.c_str());
+  case 29: {
+    double ang = atof(arg.c_str());
+    if (ang > M_PI) {
+      ang = ang * M_PI / 180.0;
+    }
+    if (ang <= 0 || ang > M_PI) {
+      std::cerr << "Error: sharp-turn-angle " << ang
+                << " is out of range (0-π)" << std::endl;
+      exit(1);
+    }
+    cfg->sharpTurnAngle = ang;
     break;
+  }
   case 30:
     cfg->renderBiDirMarker = arg.empty() ? true : toBool(arg);
     break;
@@ -281,7 +292,8 @@ void ConfigReader::help(const char *bin) const {
             << std::setw(37) << "  --crowded-line-thresh arg (=3)"
             << "lines on edge to trigger direction marker\n"
             << std::setw(37) << "  --sharp-turn-angle arg (=0.785398)"
-            << "turn angle in radians to trigger direction marker\n"
+            << "turn angle in radians (0-PI) to trigger direction marker; "
+            << "values >PI are treated as degrees\n"
             << std::setw(37) << "  -l [ --labels ]"
             << "render labels\n"
             << std::setw(37) << "  -r [ --route-labels ]"


### PR DESCRIPTION
## Summary
- add range validation and degree-to-radian conversion for `--sharp-turn-angle`
- document angle units and conversion in help text, README, and sample config

## Testing
- `cmake -S . -B build` *(fails: The source directory /workspace/loom/src/cppgtfs does not contain a CMakeLists.txt file)*

------
https://chatgpt.com/codex/tasks/task_e_68b5bc4718d0832db542ac780f4eebce