### PR TITLE
Clamp edge marker counter for short segments

### DIFF
--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -1213,6 +1213,11 @@ void SvgRenderer::renderEdgeTripGeom(const RenderGraph &outG,
 
     if (drawMarker) {
       _edgesSinceMarker[line] = 0;
+    } else if (needMarker) {
+      // Edge is too short to draw a marker but one is needed; clamp the
+      // counter so we do not exceed the forcing threshold.
+      _edgesSinceMarker[line] =
+          std::min(_edgesSinceMarker[line] + 1, 3);
     } else {
       _edgesSinceMarker[line]++;
     }

--- a/src/transitmap/tests/CMakeLists.txt
+++ b/src/transitmap/tests/CMakeLists.txt
@@ -2,5 +2,5 @@ include_directories(
 	${LOOM_INCLUDE_DIR}
 )
 
-add_executable(transitmapTest TestMain.cpp SanitizeSvgTest.cpp)
+add_executable(transitmapTest TestMain.cpp SanitizeSvgTest.cpp DirMarkerTest.cpp)
 target_link_libraries(transitmapTest transitmap_dep)

--- a/src/transitmap/tests/DirMarkerTest.cpp
+++ b/src/transitmap/tests/DirMarkerTest.cpp
@@ -1,0 +1,77 @@
+#include <sstream>
+
+#define private public
+#include "transitmap/output/SvgRenderer.h"
+#undef private
+
+#include "transitmap/tests/DirMarkerTest.h"
+#include "util/Misc.h"
+
+using transitmapper::config::Config;
+using transitmapper::output::RenderParams;
+using transitmapper::output::SvgRenderer;
+using shared::linegraph::Line;
+using shared::linegraph::LineEdge;
+using shared::linegraph::LineEdgePL;
+using shared::linegraph::LineNode;
+using shared::linegraph::LineNodePL;
+using shared::linegraph::NodeFront;
+using shared::rendergraph::RenderGraph;
+using util::geo::DPoint;
+using util::geo::PolyLine;
+
+namespace {
+LineEdge* makeEdge(RenderGraph& g, const Line* line, double length) {
+  LineNode* a = g.addNd(LineNodePL(DPoint(0, 0)));
+  LineNode* b = g.addNd(LineNodePL(DPoint(length, 0)));
+
+  PolyLine<double> pl;
+  pl << DPoint(0, 0) << DPoint(length, 0);
+  LineEdgePL epl(pl);
+  LineEdge* e = g.addEdg(a, b, epl);
+  e->pl().addLine(line, b);
+
+  NodeFront nfA(a, e);
+  PolyLine<double> nfAP;
+  nfAP << DPoint(0, 0) << DPoint(0, 1);
+  nfA.setInitialGeom(nfAP);
+  a->pl().addFront(nfA);
+
+  NodeFront nfB(b, e);
+  PolyLine<double> nfBP;
+  nfBP << DPoint(length, 0) << DPoint(length, 1);
+  nfB.setInitialGeom(nfBP);
+  b->pl().addFront(nfB);
+
+  return e;
+}
+}  // namespace
+
+void DirMarkerTest::run() {
+  Config cfg;
+  cfg.renderDirMarkers = true;
+  cfg.lineWidth = 20;
+  cfg.outlineWidth = 1;
+  cfg.lineSpacing = 10;
+  cfg.outputResolution = 1.0;
+
+  std::ostringstream out;
+  SvgRenderer renderer(&out, &cfg);
+  RenderParams params{};
+
+  Line line("L1", "L1", "#000");
+  RenderGraph g;
+
+  for (int i = 0; i < 10; ++i) {
+    LineEdge* e = makeEdge(g, &line, 10.0);
+    renderer.renderEdgeTripGeom(g, e, params);
+  }
+
+  TEST(renderer._edgesSinceMarker[&line], ==, 3);
+
+  LineEdge* longE = makeEdge(g, &line, 200.0);
+  renderer.renderEdgeTripGeom(g, longE, params);
+
+  TEST(renderer._edgesSinceMarker[&line], ==, 0);
+}
+

--- a/src/transitmap/tests/DirMarkerTest.h
+++ b/src/transitmap/tests/DirMarkerTest.h
@@ -1,0 +1,9 @@
+#ifndef TRANSITMAP_TEST_DIRMARKERTEST_H_
+#define TRANSITMAP_TEST_DIRMARKERTEST_H_
+
+class DirMarkerTest {
+ public:
+  void run();
+};
+
+#endif  // TRANSITMAP_TEST_DIRMARKERTEST_H_

--- a/src/transitmap/tests/TestMain.cpp
+++ b/src/transitmap/tests/TestMain.cpp
@@ -3,6 +3,7 @@
 
 #include "util/Misc.h"
 #include "transitmap/tests/SanitizeSvgTest.h"
+#include "transitmap/tests/DirMarkerTest.h"
 
 // _____________________________________________________________________________
 int main(int argc, char** argv) {
@@ -10,5 +11,7 @@ int main(int argc, char** argv) {
   UNUSED(argv);
   SanitizeSvgTest st;
   st.run();
+  DirMarkerTest dmt;
+  dmt.run();
   return 0;
 }


### PR DESCRIPTION
## Summary
- Prevent `_edgesSinceMarker` from exceeding the threshold when a marker is needed but not drawn
- Add DirMarkerTest to ensure markers are forced after three short edges once a long edge appears

## Testing
- `cmake -S . -B build`
- `cmake --build build --target transitmapTest`
- `./build/transitmapTest`


------
https://chatgpt.com/codex/tasks/task_e_68b653c9242c832db2a8d4655bc7cdec