### PR TITLE
Render arrowheads for tails on unidirectional edges

### DIFF
--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -1263,6 +1263,7 @@ void SvgRenderer::renderEdgeTripGeom(const RenderGraph &outG,
                 firstPart.getSegmentAtDist(tailStart, firstPart.getLength());
 
             renderLinePart(tail, lineW, *line, "stroke:black", "stroke:none");
+            renderArrowHead(tail, lineW);
           }
           renderLinePart(firstPart, lineW, *line, css, oCss);
           renderArrowHead(firstPart, lineW);
@@ -1273,6 +1274,7 @@ void SvgRenderer::renderEdgeTripGeom(const RenderGraph &outG,
             PolyLine<double> tail =
                 revSecond.getSegmentAtDist(tailStart, revSecond.getLength());
             renderLinePart(tail, lineW, *line, "stroke:black", "stroke:none");
+            renderArrowHead(tail, lineW);
           }
           renderLinePart(revSecond, lineW, *line, css, oCss);
           renderArrowHead(revSecond, lineW);


### PR DESCRIPTION
## Summary
- Draw arrowheads on tail segments when rendering unidirectional edges so direction markers include the tail.

## Testing
- `cmake -S . -B build` *(fails: The source directory /workspace/loom/src/cppgtfs does not contain a CMakeLists.txt file)*
- `git submodule update --init --recursive` *(fails: unable to access 'https://github.com/ad-freiburg/cppgtfs.git': CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b6582f8e5c832da3e4460133dfd75d