### PR TITLE
Store station label orientation for reuse

### DIFF
--- a/src/shared/linegraph/LineNodePL.cpp
+++ b/src/shared/linegraph/LineNodePL.cpp
@@ -63,6 +63,8 @@ util::json::Dict LineNodePL::getAttrs() const {
   if (_is.size() > 0) {
     obj["station_id"] = _is.begin()->id;
     obj["station_label"] = _is.begin()->name;
+    if (_is.begin()->labelDeg != std::numeric_limits<size_t>::max())
+      obj["label_deg"] = _is.begin()->labelDeg;
   }
 
   auto arr = util::json::Array();
@@ -104,6 +106,9 @@ void LineNodePL::addStop(const Station& i) { _is.push_back(i); }
 
 // _____________________________________________________________________________
 const std::vector<Station>& LineNodePL::stops() const { return _is; }
+
+// _____________________________________________________________________________
+std::vector<Station>& LineNodePL::stops() { return _is; }
 
 // _____________________________________________________________________________
 void LineNodePL::clearStops() { _is.clear(); }

--- a/src/shared/linegraph/LineNodePL.h
+++ b/src/shared/linegraph/LineNodePL.h
@@ -11,6 +11,7 @@
 #include "util/geo/GeoGraph.h"
 #include "util/graph/Edge.h"
 #include "util/graph/Node.h"
+#include <limits>
 
 namespace shared {
 namespace linegraph {
@@ -51,6 +52,7 @@ struct Station {
       : id(id), name(name), pos(pos) {}
   std::string id, name;
   util::geo::DPoint pos;
+  size_t labelDeg = std::numeric_limits<size_t>::max();
 };
 
 struct ConnException {
@@ -71,6 +73,7 @@ class LineNodePL : util::geograph::GeoNodePL<double> {
 
   void addStop(const Station& i);
   const std::vector<Station>& stops() const;
+  std::vector<Station>& stops();
   void clearStops();
 
   // TODO refactor, all front related stuff should go into rendergraph

--- a/src/transitmap/label/Labeller.cpp
+++ b/src/transitmap/label/Labeller.cpp
@@ -390,6 +390,12 @@ void Labeller::labelStations(const RenderGraph &g, bool notdeg2) {
         30 * cand.deg, *n->pl().getGeom());
     cand.geom = PolyLine<double>(cand.band[0]);
 
+    auto* nn = const_cast<shared::linegraph::LineNode*>(n);
+    if (!nn->pl().stops().empty()) {
+      nn->pl().stops()[0].labelDeg = cand.deg;
+      cand.s.labelDeg = cand.deg;
+    }
+
     _stationLabels.push_back(cand);
     _statLblIdx.add(cand.band, _stationLabels.size() - 1);
   }
@@ -617,6 +623,14 @@ const std::vector<LineLabel> &Labeller::getLineLabels() const {
 // _____________________________________________________________________________
 const std::vector<StationLabel> &Labeller::getStationLabels() const {
   return _stationLabels;
+}
+
+// _____________________________________________________________________________
+std::vector<size_t> Labeller::getStationLabelDegrees() const {
+  std::vector<size_t> ret;
+  ret.reserve(_stationLabels.size());
+  for (const auto &sl : _stationLabels) ret.push_back(sl.deg);
+  return ret;
 }
 
 // _____________________________________________________________________________

--- a/src/transitmap/label/Labeller.h
+++ b/src/transitmap/label/Labeller.h
@@ -126,6 +126,7 @@ class Labeller {
 
   const std::vector<LineLabel>& getLineLabels() const;
   const std::vector<StationLabel>& getStationLabels() const;
+  std::vector<size_t> getStationLabelDegrees() const;
 
   bool addLandmark(const util::geo::Box<double>& box);
   bool collidesWithLabels(const util::geo::Box<double>& box) const;

--- a/src/transitmap/output/MvtRenderer.cpp
+++ b/src/transitmap/output/MvtRenderer.cpp
@@ -9,6 +9,7 @@
 #include <sys/types.h>
 
 #include <fstream>
+#include <limits>
 
 #include "shared/linegraph/Line.h"
 #include "shared/rendergraph/RenderGraph.h"
@@ -102,8 +103,11 @@ void MvtRenderer::outputNodes(const RenderGraph& outG) {
       params["color"] = "000";
       params["fillColor"] = "fff";
       if (n->pl().stops().size()) {
-        params["stationLabel"] = n->pl().stops().front().name;
-        params["stationId"] = n->pl().stops().front().id;
+        const auto& st = n->pl().stops().front();
+        params["stationLabel"] = st.name;
+        params["stationId"] = st.id;
+        if (st.labelDeg != std::numeric_limits<size_t>::max())
+          params["labelDeg"] = util::toString(st.labelDeg);
       }
       params["width"] = util::toString((_cfg->lineWidth / 2));
 


### PR DESCRIPTION
## Summary
- Track label orientation in `Station` and propagate during labeling
- Expose labeled station degrees via new Labeller accessor
- Include stored label orientation in node attributes and MVT output

## Testing
- `cmake ..` *(fails: src/cppgtfs missing CMakeLists.txt)*

------
https://chatgpt.com/codex/tasks/task_e_68b65db57a8c832d82de05b1f233dbe1