### PR TITLE
Prevent station label alignment overlaps

### DIFF
--- a/src/transitmap/label/Labeller.cpp
+++ b/src/transitmap/label/Labeller.cpp
@@ -345,9 +345,15 @@ void Labeller::labelStations(const RenderGraph &g, bool notdeg2) {
             std::max(_cfg->stationLabelSize, diag);
 
         auto overlaps = getOverlaps(band, n, g, searchRad);
-        if (overlaps.lineOverlaps + overlaps.statLabelOverlaps +
-                overlaps.statOverlaps + overlaps.landmarkOverlaps >
-            0)
+        // Avoid placing station labels that collide with any existing map
+        // features. Previously we ignored overlaps with line and terminus
+        // labels which could lead to station labels being positioned on top
+        // of route lines when their alignment was inherited from neighbouring
+        // stations. Include these in the rejection criteria so aligned labels
+        // are only kept if they do not intersect any route related features.
+        if (overlaps.lineOverlaps + overlaps.lineLabelOverlaps +
+                overlaps.statLabelOverlaps + overlaps.termLabelOverlaps +
+                overlaps.statOverlaps + overlaps.landmarkOverlaps > 0)
           continue;
 
         // measure local crowding to discourage labels in dense regions


### PR DESCRIPTION
## Summary
- ensure station labels aligned with neighbours don't overlap any route-related features by rejecting candidates colliding with line or terminus labels

## Testing
- `cmake ..` *(fails: The source directory /workspace/loom/src/cppgtfs does not contain a CMakeLists.txt file)*
- `git submodule update --init --recursive` *(fails: unable to access https://github.com/ad-freiburg/cppgtfs.git)*

------
https://chatgpt.com/codex/tasks/task_e_68b665fdb8ec832d9f386dd8b58e8262