### PR TITLE
Use actual edge length for direction marker tails

### DIFF
--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -1200,8 +1200,9 @@ void SvgRenderer::renderEdgeTripGeom(const RenderGraph &outG,
     double tailWorld = 15.0 / _cfg->outputResolution;
     double minLengthForTail = arrowLength * 3 + tailWorld;
     bool sharpAngle = hasSharpAngle(e, center, line);
+    double pLen = p.getLength();
     bool useTail = _cfg->renderMarkersTail &&
-                   center.getLength() > minLengthForTail &&
+                   pLen > minLengthForTail &&
                    (_cfg->tailIgnoreSharpAngle || !sharpAngle);
 
     std::string css, oCss;
@@ -1213,7 +1214,7 @@ void SvgRenderer::renderEdgeTripGeom(const RenderGraph &outG,
 
     bool needMarker = (_cfg->renderDirMarkers && needsDirMarker(e, center, line)) ||
                       sharpAngle;
-    bool drawMarker = needMarker && center.getLength() > arrowLength * 3;
+    bool drawMarker = needMarker && pLen > arrowLength * 3;
 
     if (drawMarker) {
       _edgesSinceMarker[line] = 0;


### PR DESCRIPTION
## Summary
- ensure direction marker tail and marker rendering use the visible edge length rather than the center geometry length

## Testing
- `cmake ..` *(fails: The source directory /workspace/loom/src/cppgtfs does not contain a CMakeLists.txt file)*
- `git submodule update --init --recursive` *(fails: unable to access https://github.com/ad-freiburg/cppgtfs.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b66b3ef390832d983555b38455772e