### PR TITLE
docs: document station overlap pruning

### DIFF
--- a/src/transitmap/graph/GraphBuilder.h
+++ b/src/transitmap/graph/GraphBuilder.h
@@ -34,6 +34,11 @@ class GraphBuilder {
 
   void writeNodeFronts(shared::rendergraph::RenderGraph* g);
   void expandOverlappinFronts(shared::rendergraph::RenderGraph* g);
+  /**
+   * Remove smaller overlapping non-terminus stations using an R-tree spatial
+   * index. Terminus stations are preserved to avoid orphaned lines. Clears the
+   * node stops of dropped stations as a side effect.
+   */
   void dropOverlappingStations(shared::rendergraph::RenderGraph* g);
 
  private:


### PR DESCRIPTION
## Summary
- document dropOverlappingStations behavior and R-tree implementation

## Testing
- `cmake -S . -B build` (fails: could not find required dependencies such as GLPK and COIN libraries)


------
https://chatgpt.com/codex/tasks/task_e_68b671cd660c832d919baec2fe6ac512