### PR TITLE
Balance SVG route label rows

### DIFF
--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -1615,8 +1615,8 @@ void SvgRenderer::renderLineLabels(const Labeller &labeller,
     };
 
     if (_cfg->compactRouteLabel && label.lines.size() > 4) {
-      size_t perRow = 4;
-      size_t rows = (label.lines.size() + perRow - 1) / perRow;
+      size_t rows = (label.lines.size() + 3) / 4;
+      size_t perRow = (label.lines.size() + rows - 1) / rows;
       for (size_t r = 0; r < rows; ++r) {
         size_t start = r * perRow;
         size_t end = std::min(start + perRow, label.lines.size());


### PR DESCRIPTION
## Summary
- balance compact route labels across rows using computed row count and per-row size

## Testing
- `cmake ..` *(fails: The source directory /workspace/loom/src/cppgtfs does not contain a CMakeLists.txt file)*
- `python - <<'PY'
for n in range(5,9):
    rows = (n + 3) // 4
    perRow = (n + rows - 1) // rows
    print(n, 'labels ->', rows, 'rows of up to', perRow)
    for r in range(rows):
        start = r * perRow
        end = min(start + perRow, n)
        print(' row', r, 'gets labels', list(range(start, end)))
    print()
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b685cb6030832dbd7c57b1b8942089