### PR TITLE
Render compact route labels symmetrically

### DIFF
--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -1617,10 +1617,13 @@ void SvgRenderer::renderLineLabels(const Labeller &labeller,
     if (_cfg->compactRouteLabel && label.lines.size() > 4) {
       size_t rows = (label.lines.size() + 3) / 4;
       size_t perRow = (label.lines.size() + rows - 1) / rows;
+      double offsetStep = 1.2;
       for (size_t r = 0; r < rows; ++r) {
         size_t start = r * perRow;
         size_t end = std::min(start + perRow, label.lines.size());
-        emitRow(start, end, r * 1.2);
+        double rowOff =
+            (static_cast<double>(r) - (rows - 1) / 2.0) * offsetStep;
+        emitRow(start, end, rowOff);
       }
     } else {
       emitRow(0, label.lines.size(), 0.0);


### PR DESCRIPTION
## Summary
- Offset multi-row route labels symmetrically around the path for alternating placement above/below edges

## Testing
- `g++ -std=c++17 -c src/transitmap/output/SvgRenderer.cpp -I. -Isrc && ls -1 SvgRenderer.o`
- `git submodule update --init --recursive` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b6866d9958832dacf4a3806e651de3