### PR TITLE
Add configurable direction marker spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ Command-line parameters
 * `--line-spacing <px>`: spacing between transit lines (default `10`).
 * `--outline-width <px>`: width of line outlines (default `1`).
 * `--render-dir-markers` and `--render-markers-tail`: render line direction markers and tails.
+* `--dir-marker-spacing <n>`: edges between forced direction markers (default `1`).
 * `--bi-dir-marker`: render markers for bidirectional edges (default off).
 * `--crowded-line-thresh <n>`: lines on edge to trigger direction marker (default `3`).
 * `--sharp-turn-angle <rad>`: turn angle in radians (0-π) to trigger direction marker (default `0.785398`). Values >π are treated as degrees.

--- a/src/transitmap/config/ConfigReader.cpp
+++ b/src/transitmap/config/ConfigReader.cpp
@@ -119,6 +119,9 @@ void applyOption(Config* cfg, int c, const std::string& arg,
   case 10:
     cfg->renderDirMarkers = arg.empty() ? true : toBool(arg);
     break;
+  case 50:
+    cfg->dirMarkerSpacing = atoi(arg.c_str());
+    break;
   case 20:
     cfg->renderMarkersTail = arg.empty() ? true : toBool(arg);
     break;
@@ -296,6 +299,8 @@ void ConfigReader::help(const char *bin) const {
             << "render line direction markers\n"
             << std::setw(37) << "  --render-markers-tail"
             << "add tail to direction markers\n"
+            << std::setw(37) << "  --dir-marker-spacing arg (=1)"
+            << "edges between forced direction markers\n"
             << std::setw(37) << "  --bi-dir-marker"
             << "render markers for bidirectional edges\n"
             << std::setw(37) << "  --crowded-line-thresh arg (=3)"
@@ -410,7 +415,8 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
       {"compact-route-label", 49}, {"no-render-stations", 7},
       {"labels", 'l'},            {"route-labels", 'r'},
       {"tight-stations", 9},     {"render-dir-markers", 10},
-      {"render-markers-tail", 20}, {"tail-ignore-sharp-angle", 47},
+      {"render-markers-tail", 20}, {"dir-marker-spacing", 50},
+      {"tail-ignore-sharp-angle", 47},
       {"no-render-node-connections", 11},
       {"resolution", 12},        {"padding", 13},
       {"padding-top", 23},       {"padding-right", 24},
@@ -513,6 +519,7 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
       {"tight-stations", no_argument, 0, 9},
       {"render-dir-markers", no_argument, 0, 10},
       {"render-markers-tail", no_argument, 0, 20},
+      {"dir-marker-spacing", required_argument, 0, 50},
       {"tail-ignore-sharp-angle", no_argument, 0, 47},
       {"no-render-node-connections", no_argument, 0, 11},
       {"resolution", required_argument, 0, 12},

--- a/src/transitmap/config/TransitMapConfig.h
+++ b/src/transitmap/config/TransitMapConfig.h
@@ -80,6 +80,7 @@ struct Config {
   std::vector<size_t> mvtZooms;
 
   bool renderDirMarkers = false;
+  size_t dirMarkerSpacing = 1;
   bool renderMarkersTail = false;
   bool tailIgnoreSharpAngle = false;
   bool renderBiDirMarker = false;

--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -1134,7 +1134,7 @@ bool SvgRenderer::needsDirMarker(const shared::linegraph::LineEdge *e,
     return true;
   }
 
-  if (_edgesSinceMarker[line] >= 3) {
+  if (_edgesSinceMarker[line] >= static_cast<int>(_cfg->dirMarkerSpacing)) {
     return true;
   }
 
@@ -1222,7 +1222,8 @@ void SvgRenderer::renderEdgeTripGeom(const RenderGraph &outG,
       // Edge is too short to draw a marker but one is needed; clamp the
       // counter so we do not exceed the forcing threshold.
       _edgesSinceMarker[line] =
-          std::min(_edgesSinceMarker[line] + 1, 3);
+          std::min(_edgesSinceMarker[line] + 1,
+                   static_cast<int>(_cfg->dirMarkerSpacing));
     } else {
       _edgesSinceMarker[line]++;
     }

--- a/src/transitmap/tests/DirMarkerTest.cpp
+++ b/src/transitmap/tests/DirMarkerTest.cpp
@@ -67,7 +67,7 @@ void DirMarkerTest::run() {
     renderer.renderEdgeTripGeom(g, e, params);
   }
 
-  TEST(renderer._edgesSinceMarker[&line], ==, 3);
+  TEST(renderer._edgesSinceMarker[&line], ==, 1);
 
   LineEdge* longE = makeEdge(g, &line, 200.0);
   renderer.renderEdgeTripGeom(g, longE, params);


### PR DESCRIPTION
## Summary
- add `dirMarkerSpacing` config with default 1
- support `--dir-marker-spacing` CLI flag and document usage
- drive direction marker placement from `dirMarkerSpacing`

## Testing
- `cmake ..` *(fails: The source directory /workspace/loom/src/cppgtfs does not contain a CMakeLists.txt file)*
- `git submodule update --init --recursive` *(fails: unable to access 'https://github.com/ad-freiburg/cppgtfs.git/': CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b69bda27e0832db9abd331519d2860