### PR TITLE
Refine station label sanitization

### DIFF
--- a/src/transitmap/util/String.h
+++ b/src/transitmap/util/String.h
@@ -11,20 +11,13 @@ namespace util {
 inline std::string sanitizeStationLabel(const std::string& input) {
   std::wstring_convert<std::codecvt_utf8<wchar_t>> conv;
   std::wstring ws = conv.from_bytes(input);
+  std::locale loc("");
   std::wstring out;
-  bool prevUnderscore = false;
-  std::locale loc;
   for (wchar_t c : ws) {
-    if (std::isalnum(c, loc)) {
-      out.push_back(c);
-      prevUnderscore = false;
-    } else if (!prevUnderscore) {
-      out.push_back(L'_');
-      prevUnderscore = true;
+    if (std::iswalnum(c, loc)) {
+      out.push_back(std::towlower(c, loc));
     }
   }
-  while (!out.empty() && out.front() == L'_') out.erase(out.begin());
-  while (!out.empty() && out.back() == L'_') out.pop_back();
   return conv.to_bytes(out);
 }
 


### PR DESCRIPTION
## Summary
- Normalize station labels with locale-aware wide character processing
- Skip non-alphanumeric characters and lowercase retained characters

## Testing
- `cmake ..` *(fails: source directory /workspace/loom/src/cppgtfs does not contain a CMakeLists.txt file)*

------
https://chatgpt.com/codex/tasks/task_e_68b862930818832db976477104cd06fe