### PR TITLE
Sanitize station name comparisons in LineGraph

### DIFF
--- a/src/shared/linegraph/LineGraph.cpp
+++ b/src/shared/linegraph/LineGraph.cpp
@@ -10,6 +10,7 @@
 #include "shared/style/LineStyle.h"
 #include "util/Misc.h"
 #include "util/String.h"
+#include "transitmap/util/String.h"
 #include "util/graph/Algorithm.h"
 #include "util/graph/Edge.h"
 #include "util/graph/Node.h"
@@ -1241,8 +1242,9 @@ breakfor:
             (n1->pl().stops().size() == 0 || n1->getAdjList().size() > 1) &&
             (n1->pl().stops().size() == 0 ||
              e->getOtherNd(n1)->pl().stops().size() == 0 ||
-             n1->pl().stops().front().name ==
-                 e->getOtherNd(n1)->pl().stops().front().name)) {
+             util::sanitizeStationLabel(n1->pl().stops().front().name) ==
+                 util::sanitizeStationLabel(
+                     e->getOtherNd(n1)->pl().stops().front().name))) {
           // first contract edges with lower number of adjacent nodes,
           // on ties use shorter edge
           cands.push_back({e->getFrom()->getDeg() + e->getTo()->getDeg() +


### PR DESCRIPTION
## Summary
- include `transitmap/util/String.h` to access station-label sanitization
- compare station names using `util::sanitizeStationLabel`

## Testing
- `cmake ..` *(fails: The source directory `/workspace/loom/src/cppgtfs` does not contain a CMakeLists.txt file)*
- `git submodule update --init --recursive` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b8629579f4832d829ad71c519acc9a