### PR TITLE
Link transitmap against ICU and document dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Requirements
 
  * `cmake`
  * `gcc >= 5.0` (or `clang >= 3.9`)
+ * `libicu` development files (e.g., `libicu-dev`)
  * Optional: `libglpk-dev`, `coinor-libcbc-dev`, `gurobi`, `libzip-dev`, `libprotobuf-dev`
  * Optional: `freetype2` (libfreetype) for accurate label rendering
 
@@ -60,6 +61,13 @@ git clone --recurse-submodules https://github.com/ad-freiburg/loom.git
 ```
 
 Build and install:
+
+Make sure the ICU development package is installed before configuring the
+project, for example on Debian/Ubuntu:
+
+```bash
+sudo apt-get install libicu-dev
+```
 
 ```
 cd loom

--- a/src/transitmap/CMakeLists.txt
+++ b/src/transitmap/CMakeLists.txt
@@ -10,6 +10,7 @@ include_directories(
 )
 
 find_package(Freetype)
+find_package(ICU REQUIRED COMPONENTS uc i18n)
 if (FREETYPE_FOUND)
   include_directories(${FREETYPE_INCLUDE_DIRS})
 endif()
@@ -28,6 +29,7 @@ add_executable(transitmap ${transitmap_main})
 add_library(transitmap_dep ${transitmap_SRC})
 add_dependencies(transitmap_dep label_fonts)
 target_link_libraries(transitmap_dep PUBLIC shared_dep util dot_dep)
+target_link_libraries(transitmap_dep PUBLIC ICU::uc ICU::i18n)
 
 if (FREETYPE_FOUND)
   target_link_libraries(transitmap_dep PUBLIC ${FREETYPE_LIBRARIES})


### PR DESCRIPTION
## Summary
- Link transitmap against ICU by finding ICU components and linking imported targets
- Document ICU development package requirement in build instructions

## Testing
- `cmake -S . -B build` *(fails: The source directory /workspace/loom/src/cppgtfs does not contain a CMakeLists.txt file)*

------
https://chatgpt.com/codex/tasks/task_e_68b955351adc832da41c60f54a630194