### PR TITLE
Link ICU in shared library

### DIFF
--- a/src/shared/CMakeLists.txt
+++ b/src/shared/CMakeLists.txt
@@ -1,3 +1,5 @@
+find_package(ICU REQUIRED COMPONENTS uc i18n)
+
 file(GLOB_RECURSE shared_SRC *.cpp)
 
 include_directories(
@@ -10,3 +12,4 @@ include_directories(
 add_subdirectory(tests)
 
 add_library(shared_dep ${shared_SRC})
+target_link_libraries(shared_dep PUBLIC ICU::uc ICU::i18n)


### PR DESCRIPTION
## Summary
- link ICU components to shared_dep library

## Testing
- `cmake -S . -B build` *(fails: The source directory `/workspace/loom/src/cppgtfs` does not contain a CMakeLists.txt file)*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*


------
https://chatgpt.com/codex/tasks/task_e_68b96e8f4d50832d8e624f6fd3eb3a6b