### PR TITLE
Add --force-landmarks option to render overlapping landmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,8 +294,8 @@ Each landmark line is either
   relative to the landmarks file.
 
 Landmarks that would overlap with existing labels, map features, or previously
-placed landmarks are skipped. To render the sample landmarks alongside a map,
-run
+placed landmarks are skipped. Use `--force-landmarks` to render them anyway.
+To render the sample landmarks alongside a map, run
 
 ```
 cat examples/stuttgart.json | loom | transitmap --landmarks examples/landmarks.txt > stuttgart-landmarks.svg

--- a/src/transitmap/config/ConfigReader.cpp
+++ b/src/transitmap/config/ConfigReader.cpp
@@ -216,6 +216,9 @@ void applyOption(Config* cfg, int c, const std::string& arg,
     }
     break;
   }
+  case 51:
+    cfg->forceLandmarks = arg.empty() ? true : toBool(arg);
+    break;
   case 41:
     cfg->meStarSize = atof(arg.c_str());
     break;
@@ -381,6 +384,8 @@ void ConfigReader::help(const char *bin) const {
             << std::setw(37) << "  --landmarks arg"
             << "read landmarks from file, one word:text,lat,lon[,size[,color]] "
                "or iconPath,lat,lon[,size] per line\n"
+            << std::setw(37) << "  --force-landmarks"
+            << "render landmarks even if they overlap existing geometry\n"
             << std::setw(37) << "  --me arg"
             << "mark current location lat,lon with star\n"
             << std::setw(37) << "  --me-size arg (=150)"
@@ -428,6 +433,7 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
       {"zoom", 'z'},             {"mvt-path", 17},
       {"random-colors", 18},     {"print-stats", 19},
       {"landmark", 21},          {"landmarks", 22},
+      {"force-landmarks", 51},
       {"me-size", 41},           {"me-label", 42},
       {"me", 39},                {"me-station", 43},
       {"me-station-fill", 44},   {"me-station-border", 45}};
@@ -541,6 +547,7 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
       {"print-stats", no_argument, 0, 19},
       {"landmark", required_argument, 0, 21},
       {"landmarks", required_argument, 0, 22},
+      {"force-landmarks", no_argument, 0, 51},
       {"me-size", required_argument, 0, 41},
       {"me-label", no_argument, 0, 42},
       {"me", required_argument, 0, 39},

--- a/src/transitmap/config/TransitMapConfig.h
+++ b/src/transitmap/config/TransitMapConfig.h
@@ -90,6 +90,9 @@ struct Config {
 
   std::vector<Landmark> landmarks;
 
+  // Render landmarks even when overlapping existing geometry when enabled.
+  bool forceLandmarks = false;
+
   std::string meStation;
   std::string meStationFill = "#f00";
   std::string meStationBorder;

--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -584,7 +584,7 @@ void SvgRenderer::renderLandmarks(const RenderGraph &g,
     }
 
     if (!lm.iconPath.empty()) {
-      if (overlaps)
+      if (overlaps && !_cfg->forceLandmarks)
         continue; // skip SVG landmarks overlapping existing
       auto it = iconIds.find(lm.iconPath);
       if (it == iconIds.end())
@@ -605,7 +605,7 @@ void SvgRenderer::renderLandmarks(const RenderGraph &g,
       _w.openTag("use", attrs);
       _w.closeTag();
     } else if (!lm.label.empty()) {
-      if (overlaps)
+      if (overlaps && !_cfg->forceLandmarks)
         continue; // skip text landmarks overlapping existing geometry
 
       double x = (lm.coord.getX() - rparams.xOff) * _cfg->outputResolution;


### PR DESCRIPTION
## Summary
- add `--force-landmarks` CLI flag and config option
- render SVG/text landmarks even when overlapping existing geometry
- document flag in README

## Testing
- `cmake -S . -B build` *(fails: missing submodule)*
- `git submodule update --init --recursive` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b976d26440832db38e3b9f38e56f60