### PR TITLE
Allow safe data image URIs in SVG sanitizer

### DIFF
--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -56,8 +56,9 @@ static const std::regex styleTagRe(
     R"(<\s*style[^>]*>[\s\S]*?<\s*/\s*style\s*>)", std::regex::icase);
 static const std::regex styleAttrRe(
     R"(\sstyle\s*=\s*(\"[^\"]*\"|'[^']*'))", std::regex::icase);
+// Allow data:image/... URIs but strip all other data:* URIs
 static const std::regex dataUriAttrRe(
-    R"(\s[\w:-]+\s*=\s*(\"data:[^\"]*\"|'data:[^']*'))", std::regex::icase);
+    R"(\s[\w:-]+\s*=\s*(\"data:(?!image/)[^\"]*\"|'data:(?!image/)[^']*'))", std::regex::icase);
 
 // Remove XML or DOCTYPE declarations and strip potentially dangerous
 // constructs. Returns true when unsafe content was found.


### PR DESCRIPTION
## Summary
- allow `data:image/...` URIs to pass through SVG sanitization instead of being stripped

## Testing
- `cmake ..` (fails: The source directory `/workspace/loom/src/cppgtfs` does not contain a CMakeLists.txt file)


------
https://chatgpt.com/codex/tasks/task_e_68b98a9058c4832dac7d298e40e4ea55