### PR TITLE
Allow overlapping landmarks by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Command-line parameters
 * `--landmark <spec>`: add a landmark `word:text,lat,lon[,size[,color]]` or
   `iconPath,lat,lon[,size]`.
 * `--landmarks <file>`: read landmarks from a file, one per line.
-* `--force-landmarks`: render landmarks even if they overlap existing geometry.
+* `--force-landmarks`: render landmarks even if they overlap existing geometry (default: true; pass `--force-landmarks=false` to skip overlaps).
 * `--landmarks-webmerc`: treat landmark and `--me` coordinates as already in
   Web Mercator and skip conversion.
 * `--me <lat,lon>`: mark the given coordinates with a red star (latitude and
@@ -307,7 +307,8 @@ to Web Mercator automatically. Use `--landmarks-webmerc` if the coordinates are
 already given in Web Mercator.
 
 Landmarks that would overlap with existing labels, map features, or previously
-placed landmarks are skipped. Use `--force-landmarks` to render them anyway.
+placed landmarks are rendered by default. Use `--force-landmarks=false` to skip
+those overlapping landmarks.
 To render the sample landmarks alongside a map, run
 
 ```

--- a/src/transitmap/config/ConfigReader.cpp
+++ b/src/transitmap/config/ConfigReader.cpp
@@ -244,7 +244,7 @@ void applyOption(Config* cfg, int c, const std::string& arg,
     break;
   }
   case 51:
-    cfg->forceLandmarks = arg.empty() ? true : toBool(arg);
+    cfg->renderOverlappingLandmarks = arg.empty() ? true : toBool(arg);
     break;
   case 41:
     cfg->meStarSize = atof(arg.c_str());
@@ -421,7 +421,7 @@ void ConfigReader::help(const char *bin) const {
             << "read landmarks from file, one word:text,lat,lon[,size[,color]] "
                "or iconPath,lat,lon[,size] per line\n"
             << std::setw(37) << "  --force-landmarks"
-            << "render landmarks even if they overlap existing geometry\n"
+            << "render landmarks even if they overlap existing geometry (default)\n"
             << std::setw(37) << "  --landmarks-webmerc"
             << "landmark and --me coordinates already in Web Mercator\n"
             << std::setw(37) << "  --me arg"

--- a/src/transitmap/config/TransitMapConfig.h
+++ b/src/transitmap/config/TransitMapConfig.h
@@ -100,8 +100,8 @@ struct Config {
 
   std::vector<Landmark> landmarks;
 
-  // Render landmarks even when overlapping existing geometry when enabled.
-  bool forceLandmarks = false;
+  // Render landmarks even when overlapping existing geometry.
+  bool renderOverlappingLandmarks = true;
 
   std::string meStation;
   std::string meStationFill = "#f00";

--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -645,16 +645,19 @@ void SvgRenderer::renderLandmarks(const RenderGraph &g,
     }
 
     bool overlaps = false;
-    for (const auto &b : usedBoxes) {
-      if (util::geo::intersects(lmBox, b)) {
-        overlaps = true;
-        break;
+    if (!_cfg->renderOverlappingLandmarks) {
+      for (const auto &b : usedBoxes) {
+        if (util::geo::intersects(lmBox, b)) {
+          overlaps = true;
+          break;
+        }
+      }
+      if (overlaps) {
+        continue;
       }
     }
 
     if (!lm.iconPath.empty()) {
-      if (overlaps && !_cfg->forceLandmarks)
-        continue; // skip SVG landmarks overlapping existing
       auto it = iconIds.find(lm.iconPath);
       if (it == iconIds.end())
         continue;
@@ -674,9 +677,6 @@ void SvgRenderer::renderLandmarks(const RenderGraph &g,
       _w.openTag("use", attrs);
       _w.closeTag();
     } else if (!lm.label.empty()) {
-      if (overlaps && !_cfg->forceLandmarks)
-        continue; // skip text landmarks overlapping existing geometry
-
       double x = (lm.coord.getX() - rparams.xOff) * _cfg->outputResolution;
       double y = rparams.height -
                  (lm.coord.getY() - rparams.yOff) * _cfg->outputResolution;


### PR DESCRIPTION
## Summary
- Render overlapping landmarks by default and allow opting out via `--force-landmarks=false`
- Add `renderOverlappingLandmarks` config flag and document its default behavior
- Update SVG renderer to skip overlap checks unless explicitly disabled

## Testing
- `cmake ..` *(fails: The source directory `/workspace/loom/src/cppgtfs` does not contain a CMakeLists.txt file)*
- `git submodule update --init --recursive` *(fails: unable to access 'https://github.com/ad-freiburg/cppgtfs.git/' - CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ba53cbf908832daab7411b6a444865