### PR TITLE
Warn when landmark icon is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,8 @@ Each landmark line is either
   `word:CityHall,47.92,106.91,#ff0000`.
 * `iconPath,lat,lon[,size]` – place an SVG icon from `iconPath`. The optional
   `size` also defaults to `200`. Relative `iconPath` values are resolved
-  relative to the landmarks file.
+  relative to the landmarks file. If the icon file cannot be read, a warning is
+  logged and the landmark is skipped.
 
 Landmark coordinates are interpreted as WGS84 latitude/longitude and converted
 to Web Mercator automatically. Use `--landmarks-webmerc` if the coordinates are

--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -594,6 +594,7 @@ void SvgRenderer::renderLandmarks(const RenderGraph &g,
     if (it == iconIds.end()) {
       std::ifstream iconFile(lm.iconPath);
       if (!iconFile.good()) {
+        LOG(WARN) << "Cannot read icon file \"" << lm.iconPath << "\"";
         continue;
       }
       std::stringstream buf;


### PR DESCRIPTION
## Summary
- log a warning if a landmark's SVG icon cannot be read
- document icon path warning behaviour in README

## Testing
- `cmake --build . --target transitmap`
- `./test_icon >/tmp/out.svg 2>/tmp/test_icon.log && cat /tmp/test_icon.log`


------
https://chatgpt.com/codex/tasks/task_e_68bfeb1417ec832d891e1d742fb1cad4