### PR TITLE
Center text landmark debug rectangles

### DIFF
--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -694,9 +694,11 @@ void SvgRenderer::renderLandmarks(const RenderGraph &g,
                  (lm.coord.getY() - rparams.yOff) * _cfg->outputResolution;
 
       // Black background rectangle for debugging icon visibility
+      double rectX = x - dimsPx.first / 2.0;
+      double rectY = y - dimsPx.second / 2.0;
       std::map<std::string, std::string> rectAttrs;
-      rectAttrs["x"] = util::toString(x);
-      rectAttrs["y"] = util::toString(y);
+      rectAttrs["x"] = util::toString(rectX);
+      rectAttrs["y"] = util::toString(rectY);
       rectAttrs["width"] = util::toString(dimsPx.first);
       rectAttrs["height"] = util::toString(dimsPx.second);
       rectAttrs["fill"] = "#000";


### PR DESCRIPTION
## Summary
- Offset text landmark debug rectangles by half their dimensions so they center on labels without shifting the text.

## Testing
- `make test` (fails: No rule to make target 'test')
- `ctest` (fails: No test configuration file found)


------
https://chatgpt.com/codex/tasks/task_e_68c0d852970c832db21001aa77b5eb8e