### PR TITLE
Center text-only landmarks

### DIFF
--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -689,9 +689,11 @@ void SvgRenderer::renderLandmarks(const RenderGraph &g,
       _w.openTag("use", attrs);
       _w.closeTag();
     } else if (!lm.label.empty()) {
-      double x = (lm.coord.getX() - rparams.xOff) * _cfg->outputResolution;
+      double x = (lm.coord.getX() - rparams.xOff) * _cfg->outputResolution -
+                 dimsPx.first / 2.0;
       double y = rparams.height -
-                 (lm.coord.getY() - rparams.yOff) * _cfg->outputResolution;
+                 (lm.coord.getY() - rparams.yOff) * _cfg->outputResolution -
+                 dimsPx.second / 2.0;
 
       // Black background rectangle for debugging icon visibility
       std::map<std::string, std::string> rectAttrs;
@@ -704,8 +706,8 @@ void SvgRenderer::renderLandmarks(const RenderGraph &g,
       _w.closeTag();
 
       std::map<std::string, std::string> params;
-      params["x"] = util::toString(x);
-      params["y"] = util::toString(y);
+      params["x"] = util::toString(x + dimsPx.first / 2.0);
+      params["y"] = util::toString(y + dimsPx.second / 2.0);
       params["font-size"] = util::toString(dimsPx.second);
       params["text-anchor"] = "middle";
       params["fill"] = lm.color;


### PR DESCRIPTION
## Summary
- Center text-only landmarks by offsetting coordinates by half the computed size
- Use the centered coordinates for both the background rectangle and the label text

## Testing
- `cmake ..` *(fails: source directory /workspace/loom/src/cppgtfs does not contain a CMakeLists.txt file)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d7e5ecac832d83d8171b176818d0