### PR TITLE
Log landmark details and handle missing data

### DIFF
--- a/src/shared/rendergraph/Landmark.h
+++ b/src/shared/rendergraph/Landmark.h
@@ -17,6 +17,7 @@ struct Landmark {
   std::string color = "#000";
   util::geo::DPoint coord;
   double size = 200;
+  std::string cssClass;
 };
 
 } // namespace rendergraph

--- a/src/transitmap/TransitMapMain.cpp
+++ b/src/transitmap/TransitMapMain.cpp
@@ -95,9 +95,17 @@ int main(int argc, char **argv) {
       lm.size = lmCfg.size;
       lm.coord = lmCfg.coord;
     } else {
+      LOG(WARN) << "Skipping landmark without icon or label.";
       continue;
     }
     g.addLandmark(lm);
+    std::string lmName = lm.iconPath.empty() ? lm.label : lm.iconPath;
+    if (!lm.cssClass.empty()) {
+      LOG(INFO) << "Added landmark '" << lmName << "' with css class '"
+                << lm.cssClass << "'";
+    } else {
+      LOG(INFO) << "Added landmark '" << lmName << "'";
+    }
   }
 
   LOGTO(DEBUG, std::cerr) << "Outputting to SVG ...";


### PR DESCRIPTION
## Summary
- Warn when a landmark lacks both icon and label
- Log added landmarks including optional CSS class
- Extend Landmark struct with optional cssClass field

## Testing
- `cmake ..` *(fails: The source directory /workspace/loom/src/cppgtfs does not contain a CMakeLists.txt file)*

------
https://chatgpt.com/codex/tasks/task_e_68c0e49e9dd8832da3c4806e56fcef47