### PR TITLE
Route logs to stderr

### DIFF
--- a/src/util/log/Log.h
+++ b/src/util/log/Log.h
@@ -39,7 +39,9 @@ const static char* LOGS[] = {"ERROR", "WARN ", "INFO ", "DEBUG", "DEBUG"};
 template <char LVL>
 class Log {
  public:
-  Log() { if (LVL < INFO) os = &std::cerr; else os = &std::cout; }
+  // Route all log levels to stderr to avoid mixing log output with program
+  // results written to stdout.
+  Log() { os = &std::cerr; }
   explicit Log(std::ostream* s) { os = s; }
   ~Log() { buf << std::endl; (*os) << buf.str(); }
   std::ostream& log() { return ts() << LOGS[(size_t)LVL] << ": "; }


### PR DESCRIPTION
## Summary
- Direct all util::Log output levels to stderr instead of stdout

## Testing
- `cmake ..` *(fails: The source directory /workspace/loom/src/cppgtfs does not contain a CMakeLists.txt file)*
- `g++ -std=c++17 -DLOGLEVEL=3 -I src /tmp/test_svg.cpp -o /tmp/test_svg`
- `/tmp/test_svg > /tmp/output.svg`


------
https://chatgpt.com/codex/tasks/task_e_68c0f63717bc832db4d784247afca40d