### PR TITLE
Fix landmark label parsing

### DIFF
--- a/src/transitmap/config/ConfigReader.cpp
+++ b/src/transitmap/config/ConfigReader.cpp
@@ -225,7 +225,7 @@ void applyOption(Config* cfg, int c, const std::string& arg,
       bool isWord = first.rfind("word:", 0) == 0;
       if (isWord) {
         l.label = first.substr(5);
-        l.label = util::replaceAll(l.label, " ", "");
+        util::replaceAll(l.label, " ", "");
       } else {
         l.iconPath = first;
         if (!baseDir.empty() && !l.iconPath.empty() &&

--- a/src/transitmap/tests/LandmarkProjectionTest.cpp
+++ b/src/transitmap/tests/LandmarkProjectionTest.cpp
@@ -47,6 +47,15 @@ LineEdge* makeEdge(RenderGraph& g, const Line* line, double length) {
 }  // namespace
 
 void LandmarkProjectionTest::run() {
+  {
+    Config cfg;
+    const char* argv[] = {"prog", "--landmark", "word:ЦАЙЗ,0,0,1"};
+    ConfigReader reader;
+    reader.read(&cfg, 3, const_cast<char**>(argv));
+    TEST(cfg.landmarks.size(), ==, 1);
+    TEST(cfg.landmarks[0].label, ==, "ЦАЙЗ");
+  }
+
   Config cfg;
   const char* argv[] = {"prog", "--landmark", "word:Test,0.0001,0.0001,1"};
   ConfigReader reader;


### PR DESCRIPTION
## Summary
- fix in-place label sanitization for landmarks
- add regression test ensuring landmarks preserve non-Latin labels

## Testing
- `cmake -S . -B build` *(fails: The source directory /workspace/loom/src/cppgtfs does not contain a CMakeLists.txt file)*
- `git submodule update --init src/cppgtfs` *(fails: unable to access 'https://github.com/ad-freiburg/cppgtfs.git/' -- CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c10bfe7d38832dae794092a4a91623