### PR TITLE
Handle Unicode label width in SvgRenderer

### DIFF
--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -107,8 +107,8 @@ bool sanitizeSvg(std::string &s) {
 // width of a placeholder string (ten underscores) at the configured
 // station label size. If an icon or text would exceed this width, it is
 // scaled down proportionally.
-static std::pair<double, double> getLandmarkSizePx(const Landmark &lm,
-                                                   const Config *cfg) {
+std::pair<double, double> getLandmarkSizePx(const Landmark &lm,
+                                            const Config *cfg) {
   // Compute the maximum allowed width in pixels.
   double maxWidth = cfg->stationLabelSize * cfg->outputResolution * 0.6 * 10.0; // "__________"
 
@@ -193,7 +193,9 @@ static std::pair<double, double> getLandmarkSizePx(const Landmark &lm,
   } else if (!lm.label.empty()) {
     // Convert the desired label height from map units to pixels
     double h = lm.size * cfg->outputResolution;
-    double w = lm.label.size() * (h * 0.6);
+    // Use UTF-8 aware character counting for width estimation
+    size_t cpCount = util::toWStr(lm.label).size();
+    double w = cpCount * (h * 0.6);
     if (w > maxWidth) {
       double f = maxWidth / w;
       w = maxWidth;

--- a/src/transitmap/tests/CMakeLists.txt
+++ b/src/transitmap/tests/CMakeLists.txt
@@ -2,5 +2,5 @@ include_directories(
 	${LOOM_INCLUDE_DIR}
 )
 
-add_executable(transitmapTest TestMain.cpp SanitizeSvgTest.cpp DirMarkerTest.cpp DropOverlappingStationsTest.cpp ArrowHeadDirectionTest.cpp BgMapTest.cpp LandmarkProjectionTest.cpp)
+add_executable(transitmapTest TestMain.cpp SanitizeSvgTest.cpp DirMarkerTest.cpp DropOverlappingStationsTest.cpp ArrowHeadDirectionTest.cpp BgMapTest.cpp LandmarkProjectionTest.cpp LandmarkSizeTest.cpp)
 target_link_libraries(transitmapTest transitmap_dep)

--- a/src/transitmap/tests/LandmarkSizeTest.cpp
+++ b/src/transitmap/tests/LandmarkSizeTest.cpp
@@ -1,0 +1,40 @@
+#include <string>
+
+#include "transitmap/tests/LandmarkSizeTest.h"
+#include "transitmap/config/TransitMapConfig.h"
+#include "shared/rendergraph/Landmark.h"
+#include "util/geo/Geo.h"
+#include "util/Misc.h"
+
+using transitmapper::config::Config;
+using shared::rendergraph::Landmark;
+
+// Forward declaration of the function under test
+std::pair<double, double> getLandmarkSizePx(const Landmark &lm,
+                                            const Config *cfg);
+
+void LandmarkSizeTest::run() {
+  Config cfg;
+  cfg.outputResolution = 1.0;
+  cfg.stationLabelSize = 60.0;
+
+  Landmark lm;
+  lm.coord = util::geo::DPoint(0, 0);
+  lm.size = 10.0;
+
+  // ASCII label
+  lm.label = "Hello";
+  auto dims = getLandmarkSizePx(lm, &cfg);
+  double expectedH = lm.size * cfg.outputResolution;
+  double expectedW = util::toWStr(lm.label).size() * (expectedH * 0.6);
+  TEST(dims.first, ==, expectedW);
+  TEST(dims.second, ==, expectedH);
+
+  // Multi-byte UTF-8 label
+  lm.label = "\xE4\xBD\xA0\xE5\xA5\xBD";  // "你好"
+  dims = getLandmarkSizePx(lm, &cfg);
+  expectedW = util::toWStr(lm.label).size() * (expectedH * 0.6);
+  TEST(dims.first, ==, expectedW);
+  TEST(dims.second, ==, expectedH);
+}
+

--- a/src/transitmap/tests/LandmarkSizeTest.h
+++ b/src/transitmap/tests/LandmarkSizeTest.h
@@ -1,0 +1,10 @@
+#ifndef TRANSITMAP_TEST_LANDMARKSIZETEST_H_
+#define TRANSITMAP_TEST_LANDMARKSIZETEST_H_
+
+class LandmarkSizeTest {
+ public:
+  void run();
+};
+
+#endif  // TRANSITMAP_TEST_LANDMARKSIZETEST_H_
+

--- a/src/transitmap/tests/TestMain.cpp
+++ b/src/transitmap/tests/TestMain.cpp
@@ -8,6 +8,7 @@
 #include "transitmap/tests/ArrowHeadDirectionTest.h"
 #include "transitmap/tests/BgMapTest.h"
 #include "transitmap/tests/LandmarkProjectionTest.h"
+#include "transitmap/tests/LandmarkSizeTest.h"
 
 // _____________________________________________________________________________
 int main(int argc, char** argv) {
@@ -25,5 +26,7 @@ int main(int argc, char** argv) {
   bgmt.run();
   LandmarkProjectionTest lpt;
   lpt.run();
+  LandmarkSizeTest lst;
+  lst.run();
   return 0;
 }


### PR DESCRIPTION
## Summary
- decode UTF-8 labels to count code points when estimating landmark width
- add regression tests for ASCII and multibyte labels

## Testing
- `cmake -S src/transitmap -B build/transitmap`
- `cmake --build build/transitmap --target transitmapTest` *(fails: xxd not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c10c048c50832dac3f4ea3b10eacb6