### PR TITLE
Add debug logs for landmark rendering

### DIFF
--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -644,7 +644,16 @@ void SvgRenderer::renderLandmarks(const RenderGraph &g,
         DPoint(lm.coord.getX() - halfW, lm.coord.getY() - halfH),
         DPoint(lm.coord.getX() + halfW, lm.coord.getY() + halfH));
 
+    LOG(DEBUG) << "Landmark "
+               << (!lm.iconPath.empty() ? "icon" : (!lm.label.empty() ? "label"
+                                                                     : "unknown"))
+               << " at (" << lm.coord.getX() << ", " << lm.coord.getY()
+               << ") dimsPx=(" << dimsPx.first << ", " << dimsPx.second
+               << ")";
+
     if (!util::geo::contains(renderBox, lmBox)) {
+      LOG(DEBUG) << "Skipping landmark at (" << lm.coord.getX() << ", "
+                 << lm.coord.getY() << ") outside render box";
       continue;
     }
 
@@ -657,6 +666,8 @@ void SvgRenderer::renderLandmarks(const RenderGraph &g,
         }
       }
       if (overlaps) {
+        LOG(DEBUG) << "Skipping landmark at (" << lm.coord.getX() << ", "
+                   << lm.coord.getY() << ") due to overlap";
         continue;
       }
     }


### PR DESCRIPTION
## Summary
- Log landmark type, coordinates, and pixel dimensions during SVG rendering
- Debug reasons for skipping landmarks outside render box or due to overlap

## Testing
- `git submodule update --init --recursive` *(fails: unable to access https://github.com/ad-freiburg/cppgtfs.git)*
- `cmake -S . -B build` *(fails: source directory src/cppgtfs missing)*
- `bash run_transitmap.sh -i examples/5shar.json -o /tmp/out.svg -m "5шарурд"` *(fails: missing executable /workspace/loom/topo)*

------
https://chatgpt.com/codex/tasks/task_e_68c10d894978832d944eb6fbd2e61204