### PR TITLE
Add separate font size for word landmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ Command-line parameters
 * `--render-node-fronts`: render node fronts.
 * `--bg-map <file.geojson>`: render additional GeoJSON geometry behind the network. Coordinates are expected in latitude/longitude (WGS84).
 * `--bg-map-webmerc`: treat `--bg-map` coordinates as already in Web Mercator and skip conversion.
-* `--landmark <spec>`: add a landmark `word:text,lat,lon[,size[,color]]` or
+* `--landmark <spec>`: add a landmark `word:text,lat,lon[,fontSize[,color]]` or
   `iconPath,lat,lon[,size]`.
 * `--landmarks <file>`: read landmarks from a file, one per line.
 * `--force-landmarks`: render landmarks even if they overlap existing geometry.
@@ -298,10 +298,10 @@ A sample landmarks file with matching SVG icons is provided in
 
 Each landmark line is either
 
-* `word:<text>,lat,lon[,size[,color]]` – render the given text at the latitude
-  and longitude position. The optional `size` defaults to `200` and `color` to
-  `#000`. If you want to specify only a color, omit the size, e.g.
-  `word:CityHall,47.92,106.91,#ff0000`.
+* `word:<text>,lat,lon[,fontSize[,color]]` – render the given text at the
+  latitude and longitude position. The optional `fontSize` defaults to `20` and
+  `color` to `#000`. If you want to specify only a color, omit the font size,
+  e.g. `word:CityHall,47.92,106.91,#ff0000`.
 * `iconPath,lat,lon[,size]` – place an SVG icon from `iconPath`. The optional
   `size` also defaults to `200`. Relative `iconPath` values are resolved
   relative to the landmarks file. If the icon file cannot be read, a warning is

--- a/loom.ini
+++ b/loom.ini
@@ -54,5 +54,5 @@ landmarks=../examples/landmarks.txt
 # me-station=
 # me-station-fill=#f00
 # me-station-border=
-# landmark=
+# landmark=word:Text,lat,lon[,fontSize[,color]] or iconPath,lat,lon[,size]
 # landmarks=

--- a/src/shared/rendergraph/Landmark.h
+++ b/src/shared/rendergraph/Landmark.h
@@ -17,6 +17,7 @@ struct Landmark {
   std::string color = "#474747";
   util::geo::DPoint coord;
   double size = 200;
+  double fontSize = 20;
   std::string cssClass = "landmark";
 };
 

--- a/src/transitmap/TransitMapMain.cpp
+++ b/src/transitmap/TransitMapMain.cpp
@@ -95,6 +95,7 @@ int main(int argc, char **argv) {
       lm.label = lmCfg.label;
       lm.color = lmCfg.color;
       lm.size = lmCfg.size;
+      lm.fontSize = lmCfg.fontSize;
       lm.coord = lmCfg.coord;
     } else {
       continue;

--- a/src/transitmap/config/ConfigReader.cpp
+++ b/src/transitmap/config/ConfigReader.cpp
@@ -106,7 +106,7 @@ void applyOption(Config *cfg, int c, const std::string &arg,
     break;
   case 40:
     cfg->meLabelSize = atof(arg.c_str());
-    cfg->meLandmark.size = cfg->meLabelSize;
+    cfg->meLandmark.fontSize = cfg->meLabelSize;
     break;
   case 38:
     cfg->fontSvgMax = atof(arg.c_str());
@@ -244,8 +244,12 @@ void applyOption(Config *cfg, int c, const std::string &arg,
         p = util::geo::latLngToWebMerc(p);
       }
       l.coord = p;
-      if (parts.size() >= 4)
-        l.size = atof(parts[3].c_str());
+      if (parts.size() >= 4) {
+        if (isWord)
+          l.fontSize = atof(parts[3].c_str());
+        else
+          l.size = atof(parts[3].c_str());
+      }
       if (parts.size() >= 5)
         l.color = parts[4];
       cfg->landmarks.push_back(l);
@@ -284,7 +288,7 @@ void applyOption(Config *cfg, int c, const std::string &arg,
     cfg->renderMeLabel = arg.empty() ? true : toBool(arg);
     if (cfg->renderMeLabel) {
       cfg->meLandmark.label = "YOU ARE HERE";
-      cfg->meLandmark.size = cfg->meLabelSize;
+      cfg->meLandmark.fontSize = cfg->meLabelSize;
     }
     break;
   case 39: {

--- a/src/transitmap/tests/LandmarkSizeTest.cpp
+++ b/src/transitmap/tests/LandmarkSizeTest.cpp
@@ -20,12 +20,12 @@ void LandmarkSizeTest::run() {
 
   Landmark lm;
   lm.coord = util::geo::DPoint(0, 0);
-  lm.size = 10.0;
+  lm.fontSize = 10.0;
 
   // ASCII label
   lm.label = "Hello";
   auto dims = getLandmarkSizePx(lm, &cfg);
-  double expectedH = lm.size * cfg.outputResolution;
+  double expectedH = lm.fontSize;
   double expectedW = util::toWStr(lm.label).size() * (expectedH * 0.6);
   TEST(dims.first, ==, expectedW);
   TEST(dims.second, ==, expectedH);


### PR DESCRIPTION
## Summary
- Add `fontSize` field to landmarks for text rendering
- Parse word landmark font size and propagate through rendering
- Update documentation and tests for new landmark font size

## Testing
- `cmake -S . -B build` *(fails: missing cppgtfs submodule)*
- `git submodule update --init --recursive` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c1667c9384832dbb89223fb61ce836