### PR TITLE
Include background map bounds in SVG output

### DIFF
--- a/src/transitmap/output/SvgRenderer.h
+++ b/src/transitmap/output/SvgRenderer.h
@@ -68,6 +68,8 @@ class SvgRenderer : public Renderer {
                      std::unordered_set<const shared::linegraph::LineEdge*>>
       _forceDirMarker;
 
+  util::geo::Box<double> computeBgMapBBox() const;
+
   void outputNodes(const shared::rendergraph::RenderGraph& outputGraph,
                    const RenderParams& params);
   void outputEdges(const shared::rendergraph::RenderGraph& outputGraph,

--- a/src/transitmap/tests/BgMapTest.cpp
+++ b/src/transitmap/tests/BgMapTest.cpp
@@ -99,5 +99,53 @@ void BgMapTest::run() {
   TEST(std::abs(y1 - expected) < 1e-6);
   TEST(x2, ==, 0);
   TEST(std::abs(y2) < 1e-6);
+  // Verify that background map influences overall SVG dimensions.
+  std::string path3 = "bgmap_bbox.geojson";
+  {
+    std::ofstream out(path3);
+    out << "{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"geometry\":{\"type\":\"LineString\",\"coordinates\":[[0,0],[100,100]]}}]}";
+  }
+
+  Config cfgBase;
+  const char* argvBase[] = {"prog"};
+  reader.read(&cfgBase, 1, const_cast<char**>(argvBase));
+  std::ostringstream svgBase;
+  SvgRenderer sBase(&svgBase, &cfgBase);
+  sBase.print(g);
+  std::string baseStr = svgBase.str();
+  auto parseDim = [](const std::string& s, const std::string& attr) {
+    size_t p = s.find(attr + "=\"");
+    if (p == std::string::npos) return 0.0;
+    p += attr.size() + 2;
+    size_t q = s.find("\"", p);
+    return std::stod(s.substr(p, q - p));
+  };
+  double baseW = parseDim(baseStr, "width");
+  double baseH = parseDim(baseStr, "height");
+
+  Config cfg3;
+  const char* argv3[] = {"prog", "--bg-map", path3.c_str(), "--bg-map-webmerc"};
+  reader.read(&cfg3, 4, const_cast<char**>(argv3));
+  std::ostringstream svg3;
+  SvgRenderer s3(&svg3, &cfg3);
+  s3.print(g);
+  std::string out3 = svg3.str();
+  double w = parseDim(out3, "width");
+  double h = parseDim(out3, "height");
+  auto bgBox = s3.computeBgMapBBox();
+  auto netBox = util::geo::pad(g.getBBox(),
+                               g.getMaxLineNum() *
+                                   (cfg3.lineWidth + cfg3.lineSpacing));
+  auto merged = util::geo::extendBox(bgBox, netBox);
+  double expW =
+      (merged.getUpperRight().getX() - merged.getLowerLeft().getX() +
+       cfg3.paddingLeft + cfg3.paddingRight) * cfg3.outputResolution;
+  double expH =
+      (merged.getUpperRight().getY() - merged.getLowerLeft().getY() +
+       cfg3.paddingTop + cfg3.paddingBottom) * cfg3.outputResolution;
+  TEST(std::abs(w - expW) < 1e-6);
+  TEST(std::abs(h - expH) < 1e-6);
+  TEST(w > baseW);
+  TEST(h > baseH);
 
 }


### PR DESCRIPTION
## Summary
- add helper to compute bounding box of background map GeoJSON
- merge background-map bounds into render box when present
- test that SVG width/height expand to cover background map

## Testing
- `ctest -R transitmap_test --output-on-failure` *(fails: ArrowHeadDirectionTest)*

------
https://chatgpt.com/codex/tasks/task_e_68c17a0e95f4832d9ea17b5d56756eab