### PR TITLE
Refine per-side padding defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,11 +121,12 @@ To render for example the orthoradial map from above, use a different base graph
 cat examples/stuttgart.json | loom | octi -b orthoradial | transitmap -l > stuttgart-orthorad.svg
 ```
 
-Padding can now be specified per side. For example, to add padding only to the
-top and left of the map:
+Padding can now be specified per side. When any side-specific padding is
+provided, remaining sides default to `0`. For example, to add padding only to
+the top and left of the map:
 
 ```
-cat examples/stuttgart.json | loom | transitmap --padding 0 --padding-top 50 --padding-left 20 > stuttgart-pad.svg
+cat examples/stuttgart.json | loom | transitmap --padding-top 50 --padding-left 20 > stuttgart-pad.svg
 ```
 
 Configuration
@@ -238,11 +239,14 @@ Command-line parameters
 * `--no-deg2-labels`: suppress labels for degree‑2 stations.
 * `-D`, `--from-dot`: input graph is in DOT format.
 * `--resolution <res>`: output resolution (default `0.1`).
-* `--padding <padding>`: padding around the map (`-1` for auto).
+* `--padding <padding>`: padding around the map (`-1` for auto); applied to all
+  sides if no side-specific padding is provided.
 * `--padding-top <padding>`: padding at the top of the map (`-1` for auto).
 * `--padding-right <padding>`: padding at the right side (`-1` for auto).
 * `--padding-bottom <padding>`: padding at the bottom (`-1` for auto).
 * `--padding-left <padding>`: padding at the left side (`-1` for auto).
+
+When any side-specific padding is provided, unspecified sides default to `0`.
 * `--smoothing <factor>`: input line smoothing (default `1`).
 * `--ratio <value>`: output width/height ratio (`width = height * ratio`).
 * `--tl-ratio <value>`: top-left anchored width/height ratio (default `-1`).

--- a/src/transitmap/config/ConfigReader.cpp
+++ b/src/transitmap/config/ConfigReader.cpp
@@ -216,9 +216,8 @@ void applyOption(Config *cfg, int c, const std::string &arg,
     break;
   case 58:
     cfg->geoLock = arg.empty() ? true : toBool(arg);
-    if (cfg->geoLock &&
-        cfg->geoLockBox.getLowerLeft().getX() >
-            cfg->geoLockBox.getUpperRight().getX()) {
+    if (cfg->geoLock && cfg->geoLockBox.getLowerLeft().getX() >
+                            cfg->geoLockBox.getUpperRight().getX()) {
       util::geo::DPoint ll(106.7105, 47.8521);
       util::geo::DPoint ur(107.0209, 47.9504);
       ll = util::geo::latLngToWebMerc(ll);
@@ -728,14 +727,27 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
   if (cfg->outputPadding < 0) {
     cfg->outputPadding = (cfg->lineWidth + cfg->lineSpacing);
   }
-  if (cfg->paddingTop < 0)
+
+  bool topUnset = cfg->paddingTop < 0;
+  bool rightUnset = cfg->paddingRight < 0;
+  bool bottomUnset = cfg->paddingBottom < 0;
+  bool leftUnset = cfg->paddingLeft < 0;
+
+  if (topUnset && rightUnset && bottomUnset && leftUnset) {
     cfg->paddingTop = cfg->outputPadding;
-  if (cfg->paddingRight < 0)
     cfg->paddingRight = cfg->outputPadding;
-  if (cfg->paddingBottom < 0)
     cfg->paddingBottom = cfg->outputPadding;
-  if (cfg->paddingLeft < 0)
     cfg->paddingLeft = cfg->outputPadding;
+  } else {
+    if (topUnset)
+      cfg->paddingTop = 0;
+    if (rightUnset)
+      cfg->paddingRight = 0;
+    if (bottomUnset)
+      cfg->paddingBottom = 0;
+    if (leftUnset)
+      cfg->paddingLeft = 0;
+  }
 
   if (cfg->ratio != -1 && cfg->ratio <= 0) {
     std::cerr << "Error: ratio " << cfg->ratio << " is not positive!"


### PR DESCRIPTION
## Summary
- Apply `outputPadding` to all sides only when no side-specific padding is given
- Unset sides default to 0 once any side-specific padding is provided
- Document revised padding behaviour and update usage example

## Testing
- `cmake -S . -B build` *(fails: The source directory /workspace/loom/src/cppgtfs does not contain a CMakeLists.txt file)*
- `git submodule update --init --recursive` *(fails: unable to access 'https://github.com/ad-freiburg/cppgtfs.git/': CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c18b915ec4832da226cc2251852507