### PR TITLE
feat: add background map opacity option

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ When any side-specific padding is provided, unspecified sides default to `0`.
 * `--render-node-fronts`: render node fronts.
 * `--bg-map <file.geojson>`: render additional GeoJSON geometry behind the network. Coordinates are expected in latitude/longitude (WGS84).
 * `--bg-map-webmerc`: treat `--bg-map` coordinates as already in Web Mercator and skip conversion.
+* `--bg-map-opacity <value>`: opacity for `--bg-map` geometry (default `1`).
 * `--extend-with-bgmap`: expand the output bounding box to include `--bg-map` geometry.
 * `--geo-lock [bool]`: ensure the map covers at least a default geographic bounding box (defaults to `true`).
 * `--geo-lock-bbox <south,west,north,east>`: custom bounding box for `--geo-lock` (latitude/longitude).

--- a/src/transitmap/config/ConfigReader.cpp
+++ b/src/transitmap/config/ConfigReader.cpp
@@ -216,6 +216,9 @@ void applyOption(Config *cfg, int c, const std::string &arg,
   case 53:
     cfg->bgMapWebmerc = arg.empty() ? true : toBool(arg);
     break;
+  case 60:
+    cfg->bgMapOpacity = atof(arg.c_str());
+    break;
   case 57:
     cfg->extendWithBgMap = arg.empty() ? true : toBool(arg);
     break;
@@ -473,6 +476,8 @@ void ConfigReader::help(const char *bin) const {
       << "GeoJSON file with background geometry (lat/lon, WGS84)\n"
       << std::setw(37) << "  --bg-map-webmerc"
       << "background GeoJSON already in Web Mercator\n"
+      << std::setw(37) << "  --bg-map-opacity arg (=1)"
+      << "opacity for background map geometry\n"
       << std::setw(37) << "  --extend-with-bgmap"
       << "expand output bounds using background map geometry\n"
       << std::setw(37) << "  --geo-lock"
@@ -566,6 +571,7 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
       {"me-station-border", 45},
       {"bg-map", 52},
       {"bg-map-webmerc", 53},
+      {"bg-map-opacity", 60},
       {"extend-with-bgmap", 57},
       {"geo-lock", OPT_GEO_LOCK},
       {"geo-lock-bbox", 59}};
@@ -691,6 +697,7 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
       {"me-station-border", required_argument, 0, 45},
       {"bg-map", required_argument, 0, 52},
       {"bg-map-webmerc", no_argument, 0, 53},
+      {"bg-map-opacity", required_argument, 0, 60},
       {"extend-with-bgmap", no_argument, 0, 57},
       {"geo-lock", optional_argument, 0, OPT_GEO_LOCK},
       {"geo-lock-bbox", required_argument, 0, 59},

--- a/src/transitmap/config/TransitMapConfig.h
+++ b/src/transitmap/config/TransitMapConfig.h
@@ -89,6 +89,8 @@ struct Config {
   bool bgMapWebmerc = false;
   // Extend output bounds with background map geometry when enabled.
   bool extendWithBgMap = false;
+  // Opacity for background map geometry.
+  double bgMapOpacity = 1.0;
   std::string worldFilePath;
 
   // Ensure output covers at least a specific geographic bounding box.

--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -562,7 +562,9 @@ void SvgRenderer::renderBackground(const RenderParams &rparams) {
   params["class"] = "bg-map";
   std::stringstream style;
   style << "fill:none;stroke:#ccc;stroke-width:"
-        << _cfg->lineWidth * _cfg->outputResolution;
+        << _cfg->lineWidth * _cfg->outputResolution
+        << ";stroke-opacity:" << _cfg->bgMapOpacity
+        << ";fill-opacity:" << _cfg->bgMapOpacity;
   params["style"] = style.str();
   for (const auto &f : j["features"]) {
     if (!f.contains("geometry"))

--- a/src/transitmap/tests/BgMapTest.cpp
+++ b/src/transitmap/tests/BgMapTest.cpp
@@ -68,6 +68,16 @@ void BgMapTest::run() {
   s.print(g);
   TEST(svg.str().find("bg-map") != std::string::npos, ==, true);
 
+  Config cfgOpacity;
+  const char* argvOp[] = {"prog", "--bg-map", path.c_str(),
+                          "--bg-map-opacity", "0.5"};
+  reader.read(&cfgOpacity, 5, const_cast<char**>(argvOp));
+  std::ostringstream svgOp;
+  SvgRenderer sOp(&svgOp, &cfgOpacity);
+  sOp.print(g);
+  std::string svgOpStr = svgOp.str();
+  TEST(svgOpStr.find("stroke-opacity:0.5") != std::string::npos, ==, true);
+
   // Provide lat/long coordinates and ensure they are converted to Web Mercator
   std::string path2 = "bgmap_test_latlng.geojson";
   {


### PR DESCRIPTION
## Summary
- allow configuring background map opacity via `bgMapOpacity` in TransitMapConfig
- parse new `--bg-map-opacity` flag in ConfigReader and apply in SVG rendering
- document option and test that rendered SVG includes requested opacity

## Testing
- `cmake ..` *(fails: The source directory `/workspace/loom/src/cppgtfs` does not contain a CMakeLists.txt file)*

------
https://chatgpt.com/codex/tasks/task_e_68c385e11424832db0757a36f7f5bed8