### PR TITLE
Refine station label placement

### DIFF
--- a/src/transitmap/label/Labeller.h
+++ b/src/transitmap/label/Labeller.h
@@ -94,7 +94,6 @@ struct StationLabel {
                    overlaps.statOverlaps * 20 +
                    overlaps.statLabelOverlaps * 20 +
                    overlaps.lineLabelOverlaps * 15 +
-                   overlaps.landmarkOverlaps * 20 +
                    overlaps.termLabelOverlaps * 10;
     // wrap deg to the penalty table size to avoid out of bounds access
     score += DEG_PENS[deg % DEG_PENS.size()];


### PR DESCRIPTION
## Summary
- explore more placement options with 15° station label rotations
- remove hard rejections for label overlaps and drop landmark overlap penalty
- bias station labels to stay on the same side of their routes for smoother reading

## Testing
- `cmake -S . -B build` *(fails: The source directory /workspace/loom/src/cppgtfs does not contain a CMakeLists.txt file.)*

------
https://chatgpt.com/codex/tasks/task_e_68c388457e94832dbbc99b6a1c221724