### PR TITLE
Favor line label candidates with fewer overlaps

### DIFF
--- a/src/transitmap/label/Labeller.cpp
+++ b/src/transitmap/label/Labeller.cpp
@@ -558,7 +558,7 @@ void Labeller::labelLines(const RenderGraph &g) {
             continue;
           }
 
-          bool block = false;
+          Overlaps overlaps{0, 0, 0, 0, 0, 0};
 
           for (auto neigh : g.getNeighborEdges(
                    cand.getLine(),
@@ -568,8 +568,7 @@ void Labeller::labelLines(const RenderGraph &g) {
               continue;
             if (util::geo::dist(cand.getLine(), *neigh->pl().getGeom()) <
                 (g.getTotalWidth(neigh) / 2) + (fontSize)) {
-              block = true;
-              break;
+              overlaps.lineOverlaps++;
             }
           }
 
@@ -582,8 +581,7 @@ void Labeller::labelLines(const RenderGraph &g) {
           for (auto neighId : labelNeighs) {
             auto neigh = _stationLabels[neighId];
             if (util::geo::dist(cand.getLine(), neigh.band) < (fontSize)) {
-              block = true;
-              break;
+              overlaps.statLabelOverlaps++;
             }
           }
 
@@ -605,20 +603,17 @@ void Labeller::labelLines(const RenderGraph &g) {
             if (neighLabel.lines == lines &&
                 util::geo::dist(cand.getLine(), neighLabel.geom.getLine()) <
                     20 * (_cfg->lineWidth + _cfg->lineSpacing)) {
-              block = true;
-              break;
+              overlaps.lineLabelOverlaps++;
             }
           }
 
           std::set<size_t> landmarkNeighs;
           _landmarkIdx.get(MultiLine<double>{cand.getLine()}, fontSize,
                            &landmarkNeighs);
-          if (!landmarkNeighs.empty())
-            block = true;
+          overlaps.landmarkOverlaps += landmarkNeighs.size();
 
-          if (!block)
-            cands.push_back({cand, fabs((geomLen / 2) - (start + (labelW / 2))),
-                             fontSize, lines});
+          cands.push_back({cand, fabs((geomLen / 2) - (start + (labelW / 2))),
+                           fontSize, lines, overlaps});
           start += step;
         }
       }

--- a/src/transitmap/label/Labeller.h
+++ b/src/transitmap/label/Labeller.h
@@ -18,18 +18,6 @@ namespace label {
 // starting 90 deg
 const static std::vector<double> DEG_PENS = {0, 3, 6, 4, 1, 5, 6, 2};
 
-struct LineLabel {
-  util::geo::PolyLine<double> geom;
-  double centerDist;
-  double fontSize;
-
-  std::vector<const shared::linegraph::Line*> lines;
-};
-
-inline bool operator<(const LineLabel& a, const LineLabel& b) {
-  return a.centerDist < b.centerDist;
-}
-
 struct Overlaps {
   size_t lineOverlaps;
   size_t lineLabelOverlaps;
@@ -38,6 +26,25 @@ struct Overlaps {
   size_t statOverlaps;
   size_t termLabelOverlaps;
 };
+
+struct LineLabel {
+  util::geo::PolyLine<double> geom;
+  double centerDist;
+  double fontSize;
+  std::vector<const shared::linegraph::Line*> lines;
+  Overlaps overlaps;
+
+  double getPen() const {
+    return overlaps.lineOverlaps * 20 +
+           overlaps.statLabelOverlaps * 20 +
+           overlaps.lineLabelOverlaps * 15 +
+           overlaps.landmarkOverlaps * 10 + centerDist;
+  }
+};
+
+inline bool operator<(const LineLabel& a, const LineLabel& b) {
+  return a.getPen() < b.getPen();
+}
 
 inline bool statNdCmp(const shared::linegraph::LineNode* a,
                       const shared::linegraph::LineNode* b) {


### PR DESCRIPTION
## Summary
- track overlap counts for line label candidates
- rank line labels using overlap penalties instead of skipping conflicting options

## Testing
- `cmake -S . -B build` *(fails: The source directory /workspace/loom/src/cppgtfs does not contain a CMakeLists.txt file)*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*
- `ctest --test-dir build` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_68c392d14544832d86e600dc95f1b1df