### PR TITLE
Allow labels to take precedence over landmarks

### DIFF
--- a/src/transitmap/label/Labeller.cpp
+++ b/src/transitmap/label/Labeller.cpp
@@ -349,7 +349,7 @@ void Labeller::labelStations(const RenderGraph &g, bool notdeg2) {
 
         // measure local crowding to discourage labels in dense regions
         auto neighEdges = g.getNeighborEdges(band[0], searchRad);
-        std::set<const shared::linegraph::LineNode*> neighNodes;
+        std::set<const shared::linegraph::LineNode *> neighNodes;
         for (auto e : neighEdges) {
           neighNodes.insert(e->getFrom());
           neighNodes.insert(e->getTo());
@@ -357,10 +357,11 @@ void Labeller::labelStations(const RenderGraph &g, bool notdeg2) {
         double clusterPen =
             static_cast<double>(neighEdges.size() + neighNodes.size());
 
-        bool outside = box.getLowerLeft().getX() < mapBox.getLowerLeft().getX() ||
-                        box.getLowerLeft().getY() < mapBox.getLowerLeft().getY() ||
-                        box.getUpperRight().getX() > mapBox.getUpperRight().getX() ||
-                        box.getUpperRight().getY() > mapBox.getUpperRight().getY();
+        bool outside =
+            box.getLowerLeft().getX() < mapBox.getLowerLeft().getX() ||
+            box.getLowerLeft().getY() < mapBox.getLowerLeft().getY() ||
+            box.getUpperRight().getX() > mapBox.getUpperRight().getX() ||
+            box.getUpperRight().getY() > mapBox.getUpperRight().getY();
         double outsidePen = outside ? -5.0 : 0.0;
 
         size_t diff = (deg + 24 - prefDeg) % 24;
@@ -372,11 +373,15 @@ void Labeller::labelStations(const RenderGraph &g, bool notdeg2) {
         double sameSidePen = 0.0;
         for (auto e : n->getAdjList()) {
           auto neigh = e->getFrom() == n ? e->getTo() : e->getFrom();
-          if (neigh->pl().stops().empty()) continue;
+          if (neigh->pl().stops().empty())
+            continue;
           size_t neighDeg = neigh->pl().stops()[0].labelDeg;
-          if (neighDeg == std::numeric_limits<size_t>::max()) continue;
-          double edgeVecX = neigh->pl().getGeom()->getX() - n->pl().getGeom()->getX();
-          double edgeVecY = neigh->pl().getGeom()->getY() - n->pl().getGeom()->getY();
+          if (neighDeg == std::numeric_limits<size_t>::max())
+            continue;
+          double edgeVecX =
+              neigh->pl().getGeom()->getX() - n->pl().getGeom()->getX();
+          double edgeVecY =
+              neigh->pl().getGeom()->getY() - n->pl().getGeom()->getY();
           double candAng = deg * 15.0 * M_PI / 180.0;
           double candVecX = std::cos(candAng);
           double candVecY = std::sin(candAng);
@@ -389,11 +394,10 @@ void Labeller::labelStations(const RenderGraph &g, bool notdeg2) {
             sameSidePen += 10.0;
         }
 
-        cands.emplace_back(PolyLine<double>(band[0]), band, fontSize,
-                           isTerminus, deg, offset, overlaps,
-                           sidePen + termPen + sameSidePen,
-                           _cfg->stationLineOverlapPenalty, clusterPen,
-                           outsidePen, station);
+        cands.emplace_back(
+            PolyLine<double>(band[0]), band, fontSize, isTerminus, deg, offset,
+            overlaps, sidePen + termPen + sameSidePen,
+            _cfg->stationLineOverlapPenalty, clusterPen, outsidePen, station);
       }
     }
 
@@ -407,7 +411,7 @@ void Labeller::labelStations(const RenderGraph &g, bool notdeg2) {
         15 * cand.deg, *n->pl().getGeom());
     cand.geom = PolyLine<double>(cand.band[0]);
 
-    auto* nn = const_cast<shared::linegraph::LineNode*>(n);
+    auto *nn = const_cast<shared::linegraph::LineNode *>(n);
     if (!nn->pl().stops().empty()) {
       nn->pl().stops()[0].labelDeg = cand.deg;
       cand.s.labelDeg = cand.deg;
@@ -424,7 +428,7 @@ Overlaps Labeller::getOverlaps(const util::geo::MultiLine<double> &band,
                                const RenderGraph &g, double radius) const {
   std::set<const shared::linegraph::LineEdge *> proced;
 
-  Overlaps ret{0, 0, 0, 0, 0, 0};
+  Overlaps ret{0, 0, 0, 0, 0};
 
   std::set<const shared::linegraph::LineNode *> procedNds{forNd};
 
@@ -473,10 +477,6 @@ Overlaps Labeller::getOverlaps(const util::geo::MultiLine<double> &band,
         ret.statLabelOverlaps++;
     }
   }
-
-  std::set<size_t> landmarkNeighs;
-  _landmarkIdx.get(band, radius, &landmarkNeighs);
-  ret.landmarkOverlaps += landmarkNeighs.size();
 
   return ret;
 }
@@ -613,12 +613,13 @@ void Labeller::labelLines(const RenderGraph &g) {
           std::set<size_t> landmarkNeighs;
           _landmarkIdx.get(MultiLine<double>{cand.getLine()}, fontSize,
                            &landmarkNeighs);
-          if (!landmarkNeighs.empty())
-            block = true;
+          double landmarkPen = landmarkNeighs.empty() ? 0.0 : 5.0;
 
           if (!block)
-            cands.push_back({cand, fabs((geomLen / 2) - (start + (labelW / 2))),
-                             fontSize, lines});
+            cands.push_back(
+                {cand,
+                 fabs((geomLen / 2) - (start + (labelW / 2))) + landmarkPen,
+                 fontSize, lines});
           start += step;
         }
       }
@@ -646,7 +647,8 @@ const std::vector<StationLabel> &Labeller::getStationLabels() const {
 std::vector<size_t> Labeller::getStationLabelDegrees() const {
   std::vector<size_t> ret;
   ret.reserve(_stationLabels.size());
-  for (const auto &sl : _stationLabels) ret.push_back(sl.deg);
+  for (const auto &sl : _stationLabels)
+    ret.push_back(sl.deg);
   return ret;
 }
 

--- a/src/transitmap/label/Labeller.h
+++ b/src/transitmap/label/Labeller.h
@@ -8,8 +8,8 @@
 #include "shared/linegraph/Line.h"
 #include "shared/rendergraph/RenderGraph.h"
 #include "transitmap/config/TransitMapConfig.h"
-#include "util/geo/Grid.h"
 #include "util/geo/Box.h"
+#include "util/geo/Grid.h"
 #include "util/geo/RTree.h"
 
 namespace transitmapper {
@@ -23,10 +23,10 @@ struct LineLabel {
   double centerDist;
   double fontSize;
 
-  std::vector<const shared::linegraph::Line*> lines;
+  std::vector<const shared::linegraph::Line *> lines;
 };
 
-inline bool operator<(const LineLabel& a, const LineLabel& b) {
+inline bool operator<(const LineLabel &a, const LineLabel &b) {
   return a.centerDist < b.centerDist;
 }
 
@@ -34,18 +34,19 @@ struct Overlaps {
   size_t lineOverlaps;
   size_t lineLabelOverlaps;
   size_t statLabelOverlaps;
-  size_t landmarkOverlaps;
   size_t statOverlaps;
   size_t termLabelOverlaps;
 };
 
-inline bool statNdCmp(const shared::linegraph::LineNode* a,
-                      const shared::linegraph::LineNode* b) {
+inline bool statNdCmp(const shared::linegraph::LineNode *a,
+                      const shared::linegraph::LineNode *b) {
   // first degree 1 nodes
   size_t ad = a->getDeg();
   size_t bd = b->getDeg();
-  if (ad == 1) ad = std::numeric_limits<size_t>::max();
-  if (bd == 1) bd = std::numeric_limits<size_t>::max();
+  if (ad == 1)
+    ad = std::numeric_limits<size_t>::max();
+  if (bd == 1)
+    bd = std::numeric_limits<size_t>::max();
   return (ad > bd ||
           (ad == bd && shared::linegraph::LineGraph::getLDeg(a) >
                            shared::linegraph::LineGraph::getLDeg(b)));
@@ -71,43 +72,36 @@ struct StationLabel {
 
   shared::linegraph::Station s;
 
-  StationLabel(const util::geo::PolyLine<double>& geom,
-               const util::geo::MultiLine<double>& band, double fontSize,
-               bool bold, size_t deg, size_t pos, const Overlaps& overlaps,
+  StationLabel(const util::geo::PolyLine<double> &geom,
+               const util::geo::MultiLine<double> &band, double fontSize,
+               bool bold, size_t deg, size_t pos, const Overlaps &overlaps,
                double sidePen, double lineOverlapPenalty, double clusterPen,
-               double outsidePen, const shared::linegraph::Station& s)
-      : geom(geom),
-        band(band),
-        fontSize(fontSize),
-        bold(bold),
-        deg(deg),
-        pos(pos),
-        overlaps(overlaps),
-        sidePen(sidePen),
-        lineOverlapPenalty(lineOverlapPenalty),
-        clusterPen(clusterPen),
-        outsidePen(outsidePen),
-        s(s) {}
+               double outsidePen, const shared::linegraph::Station &s)
+      : geom(geom), band(band), fontSize(fontSize), bold(bold), deg(deg),
+        pos(pos), overlaps(overlaps), sidePen(sidePen),
+        lineOverlapPenalty(lineOverlapPenalty), clusterPen(clusterPen),
+        outsidePen(outsidePen), s(s) {}
 
   double getPen() const {
-    double score = overlaps.lineOverlaps * lineOverlapPenalty +
-                   overlaps.statOverlaps * 20 +
-                   overlaps.statLabelOverlaps * 20 +
-                   overlaps.lineLabelOverlaps * 15 +
-                   overlaps.termLabelOverlaps * 10;
+    double score =
+        overlaps.lineOverlaps * lineOverlapPenalty +
+        overlaps.statOverlaps * 20 + overlaps.statLabelOverlaps * 20 +
+        overlaps.lineLabelOverlaps * 15 + overlaps.termLabelOverlaps * 10;
     // wrap deg to the penalty table size to avoid out of bounds access
     score += DEG_PENS[deg % DEG_PENS.size()];
     score += sidePen;
     score += clusterPen;
     score += outsidePen;
 
-    if (pos == 0) score += 0.5;
-    if (pos == 2) score += 0.1;
+    if (pos == 0)
+      score += 0.5;
+    if (pos == 2)
+      score += 0.1;
     return score;
   }
 };
 
-inline bool operator<(const StationLabel& a, const StationLabel& b) {
+inline bool operator<(const StationLabel &a, const StationLabel &b) {
   return a.getPen() < b.getPen();
 }
 
@@ -118,21 +112,21 @@ typedef util::geo::RTree<size_t, util::geo::Line, double> LineLblIdx;
 typedef util::geo::RTree<size_t, util::geo::Box, double> LandmarkIdx;
 
 class Labeller {
- public:
-  Labeller(const config::Config* cfg);
+public:
+  Labeller(const config::Config *cfg);
 
-  void label(const shared::rendergraph::RenderGraph& g, bool notdeg2);
+  void label(const shared::rendergraph::RenderGraph &g, bool notdeg2);
 
-  const std::vector<LineLabel>& getLineLabels() const;
-  const std::vector<StationLabel>& getStationLabels() const;
+  const std::vector<LineLabel> &getLineLabels() const;
+  const std::vector<StationLabel> &getStationLabels() const;
   std::vector<size_t> getStationLabelDegrees() const;
 
-  bool addLandmark(const util::geo::Box<double>& box);
-  bool collidesWithLabels(const util::geo::Box<double>& box) const;
+  bool addLandmark(const util::geo::Box<double> &box);
+  bool collidesWithLabels(const util::geo::Box<double> &box) const;
 
   util::geo::Box<double> getBBox() const;
 
- private:
+private:
   std::vector<LineLabel> _lineLabels;
   std::vector<StationLabel> _stationLabels;
 
@@ -142,21 +136,21 @@ class Labeller {
 
   StatLblIdx _statLblIdx;
 
-  const config::Config* _cfg;
+  const config::Config *_cfg;
 
-  void labelStations(const shared::rendergraph::RenderGraph& g, bool notdeg2);
-  void labelLines(const shared::rendergraph::RenderGraph& g);
+  void labelStations(const shared::rendergraph::RenderGraph &g, bool notdeg2);
+  void labelLines(const shared::rendergraph::RenderGraph &g);
 
-  Overlaps getOverlaps(const util::geo::MultiLine<double>& band,
-                       const shared::linegraph::LineNode* forNd,
-                       const shared::rendergraph::RenderGraph& g,
+  Overlaps getOverlaps(const util::geo::MultiLine<double> &band,
+                       const shared::linegraph::LineNode *forNd,
+                       const shared::rendergraph::RenderGraph &g,
                        double radius) const;
 
-  util::geo::MultiLine<double> getStationLblBand(
-      const shared::linegraph::LineNode* n, double fontSize, uint8_t offset,
-      const shared::rendergraph::RenderGraph& g);
+  util::geo::MultiLine<double>
+  getStationLblBand(const shared::linegraph::LineNode *n, double fontSize,
+                    uint8_t offset, const shared::rendergraph::RenderGraph &g);
 };
-}  // namespace label
-}  // namespace transitmapper
+} // namespace label
+} // namespace transitmapper
 
-#endif  // TRANSITMAP_LABEL_LABELLER_H_
+#endif // TRANSITMAP_LABEL_LABELLER_H_


### PR DESCRIPTION
## Summary
- Drop landmark overlap tracking when evaluating station labels
- Give line label candidates a small penalty instead of blocking when near landmarks
- Keep landmark placement validation so landmarks avoid existing labels

## Testing
- `cmake -S . -B build` *(fails: CMake Error at src/CMakeLists.txt:14 (add_subdirectory): The source directory /workspace/loom/src/cppgtfs does not contain a CMakeLists.txt file)*
- `git submodule update --init --recursive` *(fails: fatal: unable to access 'https://github.com/ad-freiburg/cppgtfs.git/': CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c392d2fbbc832da480b802cbe90cfd