### PR TITLE
Simplify label placement by removing landmark penalties

### DIFF
--- a/src/transitmap/label/Labeller.cpp
+++ b/src/transitmap/label/Labeller.cpp
@@ -437,7 +437,7 @@ Overlaps Labeller::getOverlaps(const util::geo::MultiLine<double> &band,
                                const RenderGraph &g, double radius) const {
   std::set<const shared::linegraph::LineEdge *> proced;
 
-  Overlaps ret{0, 0, 0, 0, 0, 0};
+  Overlaps ret{0, 0, 0, 0, 0};
 
   std::set<const shared::linegraph::LineNode *> procedNds{forNd};
 
@@ -486,10 +486,6 @@ Overlaps Labeller::getOverlaps(const util::geo::MultiLine<double> &band,
         ret.statLabelOverlaps++;
     }
   }
-
-  std::set<size_t> landmarkNeighs;
-  _landmarkIdx.get(band, radius, &landmarkNeighs);
-  ret.landmarkOverlaps += landmarkNeighs.size();
 
   return ret;
 }
@@ -571,7 +567,7 @@ void Labeller::labelLines(const RenderGraph &g) {
             continue;
           }
 
-          Overlaps overlaps{0, 0, 0, 0, 0, 0};
+          Overlaps overlaps{0, 0, 0, 0, 0};
 
           for (auto neigh : g.getNeighborEdges(
                    cand.getLine(),
@@ -619,11 +615,6 @@ void Labeller::labelLines(const RenderGraph &g) {
               overlaps.lineLabelOverlaps++;
             }
           }
-
-          std::set<size_t> landmarkNeighs;
-          _landmarkIdx.get(MultiLine<double>{cand.getLine()}, fontSize,
-                           &landmarkNeighs);
-          overlaps.landmarkOverlaps += landmarkNeighs.size();
 
           cands.push_back({cand, fabs((geomLen / 2) - (start + (labelW / 2))),
                            fontSize, lines, overlaps});

--- a/src/transitmap/label/Labeller.h
+++ b/src/transitmap/label/Labeller.h
@@ -22,7 +22,6 @@ struct Overlaps {
   size_t lineOverlaps;
   size_t lineLabelOverlaps;
   size_t statLabelOverlaps;
-  size_t landmarkOverlaps;
   size_t statOverlaps;
   size_t termLabelOverlaps;
 };
@@ -37,8 +36,7 @@ struct LineLabel {
   double getPen() const {
     return overlaps.lineOverlaps * 20 +
            overlaps.statLabelOverlaps * 20 +
-           overlaps.lineLabelOverlaps * 15 +
-           overlaps.landmarkOverlaps * 10 + centerDist;
+           overlaps.lineLabelOverlaps * 15 + centerDist;
   }
 };
 


### PR DESCRIPTION
## Summary
- Drop `landmarkOverlaps` from label overlap tracking and penalty scoring
- Let line and station labels ignore landmarks when scored
- Keep landmark placement checks to avoid label collisions

## Testing
- `cmake -S . -B build` *(fails: The source directory /workspace/loom/src/cppgtfs does not contain a CMakeLists.txt file)*
- `git submodule update --init --recursive` *(fails: unable to access 'https://github.com/ad-freiburg/cppgtfs.git/': CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c3957b3ab0832dad992f1d9ece8a4d