### PR TITLE
Guard SVG style properties and test default polygon styling

### DIFF
--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -575,7 +575,7 @@ void SvgRenderer::renderBackground(const RenderParams &rparams) {
     std::string fill = "none";
     double opacity = _cfg->bgMapOpacity;
 
-    if (f.contains("properties")) {
+    if (f.contains("properties") && f["properties"].is_object()) {
       const auto &props = f["properties"];
       auto getStr = [](const nlohmann::json &v) {
         return v.is_string() ? v.get<std::string>()
@@ -585,15 +585,15 @@ void SvgRenderer::renderBackground(const RenderParams &rparams) {
         return v.is_number() ? v.get<double>()
                              : atof(v.get<std::string>().c_str());
       };
-      if (props.contains("stroke"))
+      if (props.contains("stroke") && !props["stroke"].is_null())
         stroke = getStr(props["stroke"]);
-      if (props.contains("stroke-width"))
+      if (props.contains("stroke-width") && !props["stroke-width"].is_null())
         strokeWidth = getDouble(props["stroke-width"]);
-      if (props.contains("fill"))
+      if (props.contains("fill") && !props["fill"].is_null())
         fill = getStr(props["fill"]);
-      if (props.contains("opacity"))
+      if (props.contains("opacity") && !props["opacity"].is_null())
         opacity = getDouble(props["opacity"]);
-      if (props.contains("class"))
+      if (props.contains("class") && !props["class"].is_null())
         params["class"] += " " + getStr(props["class"]);
     }
 

--- a/src/transitmap/tests/BgMapTest.cpp
+++ b/src/transitmap/tests/BgMapTest.cpp
@@ -206,4 +206,36 @@ void BgMapTest::run() {
   }
   TEST(mpCount, ==, 2);
 
+  // Render polygons without properties and ensure default styling is applied.
+  std::string noPropPath = "bgmap_noprop.geojson";
+  {
+    std::ofstream out(noPropPath);
+    out << R"({"type":"FeatureCollection","features":[
+      {"type":"Feature","geometry":{"type":"Polygon","coordinates":[[[0,0],[0,1],[1,1],[1,0],[0,0]]]}},
+      {"type":"Feature","geometry":{"type":"MultiPolygon","coordinates":[[[[2,0],[3,0],[3,1],[2,1],[2,0]]]]}}
+    ]})";
+  }
+
+  Config cfgDefault;
+  const char *argvDefault[] = {"prog", "--bg-map", noPropPath.c_str()};
+  reader.read(&cfgDefault, 3, const_cast<char **>(argvDefault));
+  cfgDefault.outputResolution = 1.0;
+  RenderGraph gDefault;
+  makeEdge(gDefault, &line, 1.0);
+  std::ostringstream svgDefault;
+  SvgRenderer sDefault(&svgDefault, &cfgDefault);
+  sDefault.print(gDefault);
+  std::string outDefault = svgDefault.str();
+  TEST(outDefault.find("stroke:#ccc") != std::string::npos, ==, true);
+  TEST(outDefault.find("stroke-width:20") != std::string::npos, ==, true);
+  TEST(outDefault.find("fill:none") != std::string::npos, ==, true);
+  TEST(outDefault.find("stroke-opacity:1") != std::string::npos, ==, true);
+  TEST(outDefault.find("fill-opacity:1") != std::string::npos, ==, true);
+  int defaultCount = 0;
+  for (size_t pos = outDefault.find("stroke:#ccc"); pos != std::string::npos;
+       pos = outDefault.find("stroke:#ccc", pos + 1)) {
+    defaultCount++;
+  }
+  TEST(defaultCount, ==, 2);
+
 }


### PR DESCRIPTION
## Summary
- Skip background-map style overrides unless JSON values are present and non-null
- Apply default colors/opacity when polygons lack usable properties
- Test that polygons without style properties render with defaults

## Testing
- `git submodule update --init --recursive` *(fails: CONNECT tunnel failed, response 403)*
- `cmake -S . -B build` *(fails: missing src/cppgtfs/CMakeLists.txt)*


------
https://chatgpt.com/codex/tasks/task_e_68c39580922c832da5f727c6030ea5ea