### PR TITLE
test: compute landmark size from font size

### DIFF
--- a/src/transitmap/tests/LandmarkSizeTest.cpp
+++ b/src/transitmap/tests/LandmarkSizeTest.cpp
@@ -1,13 +1,13 @@
 #include <string>
 
-#include "transitmap/tests/LandmarkSizeTest.h"
-#include "transitmap/config/TransitMapConfig.h"
 #include "shared/rendergraph/Landmark.h"
-#include "util/geo/Geo.h"
+#include "transitmap/config/TransitMapConfig.h"
+#include "transitmap/tests/LandmarkSizeTest.h"
 #include "util/Misc.h"
+#include "util/geo/Geo.h"
 
-using transitmapper::config::Config;
 using shared::rendergraph::Landmark;
+using transitmapper::config::Config;
 
 // Forward declaration of the function under test
 std::pair<double, double> getLandmarkSizePx(const Landmark &lm,
@@ -20,21 +20,32 @@ void LandmarkSizeTest::run() {
 
   Landmark lm;
   lm.coord = util::geo::DPoint(0, 0);
-  lm.size = 10.0;
+  lm.fontSize = 10.0;
 
   // ASCII label
   lm.label = "Hello";
   auto dims = getLandmarkSizePx(lm, &cfg);
-  double expectedH = lm.size * cfg.outputResolution;
+  double expectedH = lm.fontSize;
   double expectedW = util::toWStr(lm.label).size() * (expectedH * 0.6);
   TEST(dims.first, ==, expectedW);
   TEST(dims.second, ==, expectedH);
 
   // Multi-byte UTF-8 label
-  lm.label = "\xE4\xBD\xA0\xE5\xA5\xBD";  // "你好"
+  lm.label = "\xE4\xBD\xA0\xE5\xA5\xBD"; // "你好"
   dims = getLandmarkSizePx(lm, &cfg);
   expectedW = util::toWStr(lm.label).size() * (expectedH * 0.6);
   TEST(dims.first, ==, expectedW);
   TEST(dims.second, ==, expectedH);
-}
 
+  // Width-capping when the computed width exceeds the maximum allowed width
+  lm.label = "Hello";  // 5 characters
+  lm.fontSize = 200.0; // yields width greater than maxWidth
+  dims = getLandmarkSizePx(lm, &cfg);
+  double maxWidth = cfg.stationLabelSize * cfg.outputResolution * 0.6 * 10.0;
+  double w = util::toWStr(lm.label).size() * (lm.fontSize * 0.6);
+  double f = maxWidth / w;
+  expectedW = maxWidth;
+  expectedH = lm.fontSize * f;
+  TEST(dims.first, ==, expectedW);
+  TEST(dims.second, ==, expectedH);
+}


### PR DESCRIPTION
## Summary
- update `LandmarkSizeTest` to size labels from `fontSize`
- verify width-capping logic when labels exceed configured max width

## Testing
- `cmake ..` *(fails: The source directory /workspace/loom/src/cppgtfs does not contain a CMakeLists.txt file)*

------
https://chatgpt.com/codex/tasks/task_e_68c39ecf2eac832d8b2a456d4c1a14f0