### PR TITLE
Normalize crowding penalty and add outside penalty option

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,8 @@ Command-line parameters
 * `--font-svg-max <size>`: max font size for station labels in SVG, -1 for no limit (default `11`).
 * `--station-line-overlap-penalty <weight>`: penalty multiplier for station-line overlaps (default `15`).
 * `--side-penalty-weight <weight>`: weight for station label side preference penalties (default `2.5`).
+* `--cluster-pen-scale <scale>`: scale factor for station crowding penalties (default `1`).
+* `--outside-penalty <weight>`: penalty (positive) or bonus (negative) for labels outside the map bounds (default `-5`).
 * `--orientation-penalties <p0,...,p7>`: comma-separated penalties for eight label orientations (default `0,3,6,4,1,5,6,2`).
 * `--route-label-gap <px>`: gap between route label boxes (default `10`).
 * `--route-label-terminus-gap <px>`: gap between terminus station label and route labels (default `80`).

--- a/src/transitmap/config/ConfigReader.cpp
+++ b/src/transitmap/config/ConfigReader.cpp
@@ -132,6 +132,12 @@ void applyOption(Config *cfg, int c, const std::string &arg,
     }
     break;
   }
+  case 65:
+    cfg->clusterPenScale = atof(arg.c_str());
+    break;
+  case 66:
+    cfg->outsidePenalty = atof(arg.c_str());
+    break;
   case 32:
     cfg->routeLabelBoxGap = atof(arg.c_str());
     break;
@@ -457,6 +463,10 @@ void ConfigReader::help(const char *bin) const {
       << std::setw(37)
       << "  --orientation-penalties arg (=0,3,6,4,1,5,6,2)"
       << "penalties for 8 label orientations\n"
+      << std::setw(37) << "  --cluster-pen-scale arg (=1)"
+      << "scale factor for station crowding penalty\n"
+      << std::setw(37) << "  --outside-penalty arg (=-5)"
+      << "penalty or bonus for labels outside map bounds\n"
       << std::setw(37) << "  --route-label-gap arg (=20)"
       << "gap between route label boxes\n"
       << std::setw(37) << "  --route-label-terminus-gap arg (=100)"
@@ -561,6 +571,8 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
       {"station-line-overlap-penalty", 37},
       {"side-penalty-weight", 61},
       {"orientation-penalties", 62},
+      {"cluster-pen-scale", 65},
+      {"outside-penalty", 66},
       {"route-label-gap", 32},
       {"route-label-terminus-gap", 34},
       {"highlight-terminal", 33},
@@ -691,6 +703,8 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
       {"station-line-overlap-penalty", required_argument, 0, 37},
       {"side-penalty-weight", required_argument, 0, 61},
       {"orientation-penalties", required_argument, 0, 62},
+      {"cluster-pen-scale", required_argument, 0, 65},
+      {"outside-penalty", required_argument, 0, 66},
       {"route-label-gap", required_argument, 0, 32},
       {"route-label-terminus-gap", required_argument, 0, 34},
       {"highlight-terminal", no_argument, 0, 33},

--- a/src/transitmap/config/TransitMapConfig.h
+++ b/src/transitmap/config/TransitMapConfig.h
@@ -32,6 +32,10 @@ struct Config {
   double meStarSize = 150;
   double stationLineOverlapPenalty = 15;
   double sidePenaltyWeight = 2.5;
+  // Scale factor for the station crowding penalty.
+  double clusterPenScale = 1.0;
+  // Penalty (positive) or bonus (negative) for labels outside the map bounds.
+  double outsidePenalty = -5.0;
   std::vector<double> orientationPenalties = {0, 3, 6, 4, 1, 5, 6, 2};
   // Maximum font size for station labels in SVG output; -1 for no limit.
   double fontSvgMax = 11;

--- a/src/transitmap/label/Labeller.cpp
+++ b/src/transitmap/label/Labeller.cpp
@@ -372,15 +372,18 @@ void Labeller::labelStations(const RenderGraph &g, bool notdeg2) {
           neighNodes.insert(e->getFrom());
           neighNodes.insert(e->getTo());
         }
-        double clusterPen =
+        double area = (box.getUpperRight().getX() - box.getLowerLeft().getX()) *
+                      (box.getUpperRight().getY() - box.getLowerLeft().getY());
+        double neighborCount =
             static_cast<double>(neighEdges.size() + neighNodes.size());
+        double clusterPen =
+            area > 0.0 ? neighborCount / area : neighborCount;
 
         bool outside =
             box.getLowerLeft().getX() < mapBox.getLowerLeft().getX() ||
             box.getLowerLeft().getY() < mapBox.getLowerLeft().getY() ||
             box.getUpperRight().getX() > mapBox.getUpperRight().getX() ||
             box.getUpperRight().getY() > mapBox.getUpperRight().getY();
-        double outsidePen = outside ? -5.0 : 0.0;
 
         size_t diff = (deg + kStationAngleSteps - prefDeg) % kStationAngleSteps;
         if (diff > kStationAngleSteps / 2)
@@ -434,8 +437,9 @@ void Labeller::labelStations(const RenderGraph &g, bool notdeg2) {
             StationLabel(PolyLine<double>(band[0]), band, fontSize, isTerminus,
                          deg, offset, overlaps,
                          sidePen + termPen + sameSidePen,
-                         _cfg->stationLineOverlapPenalty, clusterPen,
-                         outsidePen, &_cfg->orientationPenalties, station),
+                         _cfg->stationLineOverlapPenalty, clusterPen, outside,
+                         _cfg->clusterPenScale, _cfg->outsidePenalty,
+                         &_cfg->orientationPenalties, station),
             opposite});
       }
     }

--- a/src/transitmap/label/Labeller.h
+++ b/src/transitmap/label/Labeller.h
@@ -66,10 +66,11 @@ struct StationLabel {
   // penalty to discourage placing labels on the wrong side of the road
   double sidePen = 0;
   double lineOverlapPenalty = 15;
-  // penalty for placing labels in crowded regions
+  // density of nearby edges and nodes
   double clusterPen = 0;
-  // bonus for placing labels outside of the map bounds
-  double outsidePen = 0;
+  bool outside = false;
+  double clusterPenScale = 1;
+  double outsidePenalty = 0;
 
   const std::vector<double>* orientationPens = nullptr;
 
@@ -79,7 +80,7 @@ struct StationLabel {
                const util::geo::MultiLine<double>& band, double fontSize,
                bool bold, size_t deg, size_t pos, const Overlaps& overlaps,
                double sidePen, double lineOverlapPenalty, double clusterPen,
-               double outsidePen,
+               bool outside, double clusterPenScale, double outsidePenalty,
                const std::vector<double>* orientationPens,
                const shared::linegraph::Station& s)
       : geom(geom),
@@ -92,7 +93,9 @@ struct StationLabel {
         sidePen(sidePen),
         lineOverlapPenalty(lineOverlapPenalty),
         clusterPen(clusterPen),
-        outsidePen(outsidePen),
+        outside(outside),
+        clusterPenScale(clusterPenScale),
+        outsidePenalty(outsidePenalty),
         orientationPens(orientationPens),
         s(s) {}
 
@@ -107,8 +110,8 @@ struct StationLabel {
           (*orientationPens)[deg % orientationPens->size()];
     }
     score += sidePen;
-    score += clusterPen;
-    score += outsidePen;
+    score += clusterPen * clusterPenScale;
+    if (outside) score += outsidePenalty;
 
     if (pos == 0) score += 0.5;
     if (pos == 2) score += 0.1;

--- a/src/transitmap/tests/ConfigParseTest.cpp
+++ b/src/transitmap/tests/ConfigParseTest.cpp
@@ -10,15 +10,19 @@ using transitmapper::config::ConfigReader;
 void ConfigParseTest::run() {
   Config cfg;
   const char* argv[] = {"prog", "--side-penalty-weight", "4.5",
+                        "--cluster-pen-scale", "2.0",
+                        "--outside-penalty", "7.5",
                         "--orientation-penalties", "1,2,3,4,5,6,7,8",
                         "--displacement-iterations", "5",
                         "--displacement-cooling", "0.5"};
   ConfigReader reader;
-  reader.read(&cfg, 9, const_cast<char**>(argv));
+  reader.read(&cfg, 13, const_cast<char**>(argv));
   TEST(std::abs(cfg.sidePenaltyWeight - 4.5) < 1e-9);
   TEST(cfg.orientationPenalties.size(), ==, 8);
   TEST(cfg.orientationPenalties[0], ==, 1);
   TEST(cfg.orientationPenalties[7], ==, 8);
   TEST(cfg.displacementIterations, ==, 5);
   TEST(std::abs(cfg.displacementCooling - 0.5) < 1e-9);
+  TEST(std::abs(cfg.clusterPenScale - 2.0) < 1e-9);
+  TEST(std::abs(cfg.outsidePenalty - 7.5) < 1e-9);
 }

--- a/src/transitmap/tests/LabelPenaltyTest.cpp
+++ b/src/transitmap/tests/LabelPenaltyTest.cpp
@@ -30,15 +30,48 @@ void LabelPenaltyTest::run() {
   double sideB = 2 * cfgB.sidePenaltyWeight;
 
   StationLabel lblA(geom, band, 10, false, 0, 0, ov, sideA,
-                    cfgA.stationLineOverlapPenalty, 0, 0,
+                    cfgA.stationLineOverlapPenalty, 0, false,
+                    cfgA.clusterPenScale, cfgA.outsidePenalty,
                     &cfgA.orientationPenalties, st);
   StationLabel lblB(geom, band, 10, false, 0, 0, ov, sideB,
-                    cfgB.stationLineOverlapPenalty, 0, 0,
+                    cfgB.stationLineOverlapPenalty, 0, false,
+                    cfgB.clusterPenScale, cfgB.outsidePenalty,
                     &cfgB.orientationPenalties, st);
   TEST(lblB.getPen() > lblA.getPen());
 
   StationLabel lblC(geom, band, 10, false, 1, 0, ov, sideA,
-                    cfgA.stationLineOverlapPenalty, 0, 0,
+                    cfgA.stationLineOverlapPenalty, 0, false,
+                    cfgA.clusterPenScale, cfgA.outsidePenalty,
                     &cfgA.orientationPenalties, st);
   TEST(lblC.getPen() > lblA.getPen());
+
+  // crowding penalty scale
+  Config cfgC;
+  Config cfgD;
+  cfgC.clusterPenScale = 1.0;
+  cfgD.clusterPenScale = 5.0;
+  StationLabel lblD(geom, band, 10, false, 0, 0, ov, 0,
+                    cfgC.stationLineOverlapPenalty, 1.0, false,
+                    cfgC.clusterPenScale, cfgC.outsidePenalty,
+                    &cfgC.orientationPenalties, st);
+  StationLabel lblE(geom, band, 10, false, 0, 0, ov, 0,
+                    cfgD.stationLineOverlapPenalty, 1.0, false,
+                    cfgD.clusterPenScale, cfgD.outsidePenalty,
+                    &cfgD.orientationPenalties, st);
+  TEST(lblE.getPen() > lblD.getPen());
+
+  // outside penalty bonus/penalty
+  Config cfgOutPen;
+  Config cfgOutBon;
+  cfgOutPen.outsidePenalty = 5.0;
+  cfgOutBon.outsidePenalty = -5.0;
+  StationLabel lblOutPen(geom, band, 10, false, 0, 0, ov, 0,
+                         cfgOutPen.stationLineOverlapPenalty, 0, true,
+                         cfgOutPen.clusterPenScale, cfgOutPen.outsidePenalty,
+                         &cfgOutPen.orientationPenalties, st);
+  StationLabel lblOutBon(geom, band, 10, false, 0, 0, ov, 0,
+                         cfgOutBon.stationLineOverlapPenalty, 0, true,
+                         cfgOutBon.clusterPenScale, cfgOutBon.outsidePenalty,
+                         &cfgOutBon.orientationPenalties, st);
+  TEST(lblOutPen.getPen() > lblOutBon.getPen());
 }


### PR DESCRIPTION
## Summary
- normalize crowding penalty by dividing neighbor count by label area and scaling via new `clusterPenScale` option
- make boundary bias configurable with `outsidePenalty`
- document new CLI flags and expand tests

## Testing
- ⚠️ `cmake ..` *(missing submodule `src/cppgtfs`)*

------
https://chatgpt.com/codex/tasks/task_e_68c3abf8ec84832da1300c5f8c8d2d3b