### PR TITLE
Trim landmark labels instead of stripping spaces

### DIFF
--- a/src/transitmap/config/ConfigReader.cpp
+++ b/src/transitmap/config/ConfigReader.cpp
@@ -285,8 +285,7 @@ void applyOption(Config *cfg, int c, const std::string &arg,
       std::string first = parts[0];
       bool isWord = first.rfind("word:", 0) == 0;
       if (isWord) {
-        l.label = first.substr(5);
-        util::replaceAll(l.label, " ", "");
+        l.label = util::trim(first.substr(5));
         if (parts.size() >= 4)
           l.fontSize = atof(parts[3].c_str());
         if (parts.size() >= 5)

--- a/src/transitmap/tests/LandmarkProjectionTest.cpp
+++ b/src/transitmap/tests/LandmarkProjectionTest.cpp
@@ -57,6 +57,16 @@ void LandmarkProjectionTest::run() {
     TEST(std::abs(cfg.landmarks[0].opacity - 0.5) < 1e-9);
   }
 
+  {
+    Config cfg;
+    const char *argv[] = {"prog", "--landmark",
+                          "word:  spaced  label  ,0,0"};
+    ConfigReader reader;
+    reader.read(&cfg, 3, const_cast<char **>(argv));
+    TEST(cfg.landmarks.size(), ==, 1);
+    TEST(cfg.landmarks[0].label, ==, "spaced  label");
+  }
+
   Config cfg;
   const char *argv[] = {"prog", "--landmark",
                         "word:Test,0.0001,0.0001,1,#123456,0.3"};


### PR DESCRIPTION
## Summary
- Trim leading and trailing whitespace from word-based landmark labels while preserving interior spaces
- Add regression test ensuring internal spaces survive but surrounding whitespace is removed

## Testing
- `cmake ..` *(fails: /workspace/loom/src/cppgtfs missing)*
- `git submodule update --init --recursive` *(fails: unable to access https://github.com/ad-freiburg/cppgtfs.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c3af6d2704832d8e72eab3dea267a2