### PR TITLE
Add configurable same-side label penalty option

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ Command-line parameters
 * `--font-svg-max <size>`: max font size for station labels in SVG, -1 for no limit (default `11`).
 * `--station-line-overlap-penalty <weight>`: penalty multiplier for station-line overlaps (default `15`).
 * `--side-penalty-weight <weight>`: weight for station label side preference penalties (default `2.5`).
+* `--same-side-penalty <penalty>`: penalty for station labels on opposite sides (default `100`).
 * `--cluster-pen-scale <scale>`: scale factor for station crowding penalties (default `1`).
 * `--outside-penalty <weight>`: penalty (positive) or bonus (negative) for labels outside the map bounds (default `-5`).
 * `--orientation-penalties <p0,...,p7>`: comma-separated penalties for eight label orientations (default `0,3,6,4,1,5,6,2`).

--- a/src/transitmap/config/ConfigReader.cpp
+++ b/src/transitmap/config/ConfigReader.cpp
@@ -122,6 +122,9 @@ void applyOption(Config *cfg, int c, const std::string &arg,
   case 61:
     cfg->sidePenaltyWeight = atof(arg.c_str());
     break;
+  case 67:
+    cfg->sameSidePenalty = atof(arg.c_str());
+    break;
   case 62: {
     auto parts = util::split(arg, ',');
     if (parts.size() == 8) {
@@ -459,6 +462,8 @@ void ConfigReader::help(const char *bin) const {
       << "penalty multiplier for station-line overlaps\n"
       << std::setw(37) << "  --side-penalty-weight arg (=2.5)"
       << "weight for station label side preference penalties\n"
+      << std::setw(37) << "  --same-side-penalty arg (=100)"
+      << "penalty for station labels on opposite sides\n"
       << std::setw(37)
       << "  --orientation-penalties arg (=0,3,6,4,1,5,6,2)"
       << "penalties for 8 label orientations\n"
@@ -569,6 +574,7 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
       {"font-svg-max", 38},
       {"station-line-overlap-penalty", 37},
       {"side-penalty-weight", 61},
+      {"same-side-penalty", 67},
       {"orientation-penalties", 62},
       {"cluster-pen-scale", 65},
       {"outside-penalty", 66},
@@ -701,6 +707,7 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
       {"font-svg-max", required_argument, 0, 38},
       {"station-line-overlap-penalty", required_argument, 0, 37},
       {"side-penalty-weight", required_argument, 0, 61},
+      {"same-side-penalty", required_argument, 0, 67},
       {"orientation-penalties", required_argument, 0, 62},
       {"cluster-pen-scale", required_argument, 0, 65},
       {"outside-penalty", required_argument, 0, 66},

--- a/src/transitmap/config/TransitMapConfig.h
+++ b/src/transitmap/config/TransitMapConfig.h
@@ -32,6 +32,9 @@ struct Config {
   double meStarSize = 150;
   double stationLineOverlapPenalty = 15;
   double sidePenaltyWeight = 2.5;
+  // Penalty for placing station labels on the opposite side of a connecting
+  // edge.
+  double sameSidePenalty = 100;
   // Scale factor for the station crowding penalty.
   double clusterPenScale = 1.0;
   // Penalty (positive) or bonus (negative) for labels outside the map bounds.

--- a/src/transitmap/label/Labeller.cpp
+++ b/src/transitmap/label/Labeller.cpp
@@ -415,7 +415,7 @@ void Labeller::labelStations(const RenderGraph &g, bool notdeg2) {
           double candSide = edgeVecX * candVecY - edgeVecY * candVecX;
           double neighSide = edgeVecX * neighVecY - edgeVecY * neighVecX;
           if (candSide * neighSide < 0)
-            sameSidePen += 100.0;
+            sameSidePen += _cfg->sameSidePenalty;
         }
         auto prefIt = sidePrefs.find(n);
         if (prefIt != sidePrefs.end()) {
@@ -428,7 +428,7 @@ void Labeller::labelStations(const RenderGraph &g, bool notdeg2) {
                 prefNeigh->pl().getGeom()->getY() - n->pl().getGeom()->getY();
             double candSide = edgeVecX * candVecY - edgeVecY * candVecX;
             if (candSide * desired < 0)
-              sameSidePen += 100.0;
+              sameSidePen += _cfg->sameSidePenalty;
           }
         }
 

--- a/src/transitmap/tests/ConfigParseTest.cpp
+++ b/src/transitmap/tests/ConfigParseTest.cpp
@@ -14,9 +14,10 @@ void ConfigParseTest::run() {
                         "--outside-penalty", "7.5",
                         "--orientation-penalties", "1,2,3,4,5,6,7,8",
                         "--displacement-iterations", "5",
-                        "--displacement-cooling", "0.5"};
+                        "--displacement-cooling", "0.5",
+                        "--same-side-penalty", "42"};
   ConfigReader reader;
-  reader.read(&cfg, 13, const_cast<char**>(argv));
+  reader.read(&cfg, 15, const_cast<char**>(argv));
   TEST(std::abs(cfg.sidePenaltyWeight - 4.5) < 1e-9);
   TEST(cfg.orientationPenalties.size(), ==, 8);
   TEST(cfg.orientationPenalties[0], ==, 1);
@@ -25,4 +26,5 @@ void ConfigParseTest::run() {
   TEST(std::abs(cfg.displacementCooling - 0.5) < 1e-9);
   TEST(std::abs(cfg.clusterPenScale - 2.0) < 1e-9);
   TEST(std::abs(cfg.outsidePenalty - 7.5) < 1e-9);
+  TEST(std::abs(cfg.sameSidePenalty - 42) < 1e-9);
 }


### PR DESCRIPTION
## Summary
- add `sameSidePenalty` field to `TransitMapConfig` with default 100 and document it
- parse `--same-side-penalty` CLI option and use it in `Labeller`
- document the new option and cover it with a configuration parsing unit test

## Testing
- `cmake -S . -B build` *(fails: The source directory `/workspace/loom/src/cppgtfs` does not contain a CMakeLists.txt file)*
- `git submodule update --init --recursive` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c3b3a20b44832d8bea90f3c3979845