### PR TITLE
Fix duplicate case value for reposition-label option

### DIFF
--- a/src/transitmap/config/ConfigReader.cpp
+++ b/src/transitmap/config/ConfigReader.cpp
@@ -77,6 +77,9 @@ std::unordered_set<std::string> processedLandmarkFiles;
 // character. 260 is safely outside the signed char range and unique in this
 // file.
 constexpr int OPT_GEO_LOCK = 260;
+// Assign a unique code outside the ASCII range for long options without a
+// short equivalent to avoid clashes with character options such as 'D'.
+constexpr int OPT_REPOSITION_LABEL = 261;
 bool toBool(const std::string &v) {
   std::string s = util::toLower(v);
   return s == "1" || s == "true" || s == "yes" || s == "on";
@@ -125,7 +128,7 @@ void applyOption(Config *cfg, int c, const std::string &arg,
   case 67:
     cfg->sameSidePenalty = atof(arg.c_str());
     break;
-  case 68:
+  case OPT_REPOSITION_LABEL:
     cfg->repositionLabel = atoi(arg.c_str());
     break;
   case 69:
@@ -585,7 +588,7 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
       {"station-line-overlap-penalty", 37},
       {"side-penalty-weight", 61},
       {"same-side-penalty", 67},
-      {"reposition-label", 68},
+      {"reposition-label", OPT_REPOSITION_LABEL},
       {"crowding-same-side-scale", 69},
       {"orientation-penalties", 62},
       {"cluster-pen-scale", 65},
@@ -721,7 +724,7 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
       {"side-penalty-weight", required_argument, 0, 61},
       {"same-side-penalty", required_argument, 0, 67},
       {"crowding-same-side-scale", required_argument, 0, 69},
-      {"reposition-label", required_argument, 0, 68},
+      {"reposition-label", required_argument, 0, OPT_REPOSITION_LABEL},
       {"orientation-penalties", required_argument, 0, 62},
       {"cluster-pen-scale", required_argument, 0, 65},
       {"outside-penalty", required_argument, 0, 66},


### PR DESCRIPTION
## Summary
- avoid collision between `reposition-label` and `-D` options by using a non-ASCII option code
- update option mappings and switch statements to use the new constant

## Testing
- `cmake -S . -B build` *(fails: The source directory /workspace/loom/src/cppgtfs does not contain a CMakeLists.txt file)*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*


------
https://chatgpt.com/codex/tasks/task_e_68c77f0afa20832d88e93c1fc0b3b177