### PR TITLE
Ensure node terminus labels use configured gap

### DIFF
--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -2164,6 +2164,7 @@ void SvgRenderer::renderTerminusLabels(const RenderGraph &g,
     double anchorX = nodeX;
     double anchorY = nodeY;
     double clearance = 0.0;
+    bool anchorIsNode = false;
 
     switch (_cfg->terminusLabelAnchor) {
     case TerminusLabelAnchor::StationLabel:
@@ -2190,8 +2191,8 @@ void SvgRenderer::renderTerminusLabels(const RenderGraph &g,
     case TerminusLabelAnchor::Node:
       anchorX = nodeX;
       anchorY = nodeY;
-      clearance = hasFootprint ? footprintHalfHeight
-                               : (hasLabelGeom ? labelVExtent : 0.0);
+      clearance = 0.0;
+      anchorIsNode = true;
       break;
     }
 
@@ -2239,7 +2240,7 @@ void SvgRenderer::renderTerminusLabels(const RenderGraph &g,
     }
 
     double stationHalfHeight =
-        std::abs(clearance * _cfg->outputResolution);
+        anchorIsNode ? 0.0 : std::abs(clearance * _cfg->outputResolution);
 
     double stackCenterOffset = stationHalfHeight + terminusGap;
     double stackCenterY = above ? y - stackCenterOffset : y + stackCenterOffset;


### PR DESCRIPTION
## Summary
- keep node-anchored terminus labels from inheriting footprint or label clearance so spacing relies solely on the configured gap
- guard the downstream spacing calculation so node anchoring continues to use the configured gap only

## Testing
- cmake -S . -B build *(fails: missing cppgtfs submodule; cloning requires external network access)*

------
https://chatgpt.com/codex/tasks/task_e_68cae0acab88832d96452a4551f2db2c