### PR TITLE
Fix terminus detection when lines reverse

### DIFF
--- a/src/shared/linegraph/LineGraph.cpp
+++ b/src/shared/linegraph/LineGraph.cpp
@@ -1222,6 +1222,18 @@ bool LineGraph::lineContinuesByReversing(const LineNode* nd,
   if (!edge || !lo.line) return false;
   if (lo.direction != 0) return false;
 
+  bool hasContinuationAtTerminus = false;
+  for (const auto* candidate : nd->getAdjList()) {
+    if (candidate == edge) continue;
+    if (!candidate->pl().hasLine(lo.line)) continue;
+    if (lineCtd(edge, candidate, lo.line)) {
+      hasContinuationAtTerminus = true;
+      break;
+    }
+  }
+
+  if (!hasContinuationAtTerminus) return false;
+
   const LineNode* other = edge->getOtherNd(nd);
   if (!other || other == nd) return false;
 
@@ -1300,7 +1312,6 @@ bool LineGraph::terminatesAt(const LineEdge* fromEdge, const LineNode* terminus,
                              const Line* line) {
   if (!fromEdge->pl().hasLine(line)) return false;
   const LineOcc& occ = fromEdge->pl().lineOcc(line);
-  if (lineContinuesByReversing(terminus, fromEdge, occ)) return false;
   for (const auto& toEdg : terminus->getAdjList()) {
     if (toEdg == fromEdge) continue;
     if (!toEdg->pl().hasLine(line)) continue;
@@ -1308,6 +1319,7 @@ bool LineGraph::terminatesAt(const LineEdge* fromEdge, const LineNode* terminus,
       return false;
     }
   }
+  if (lineContinuesByReversing(terminus, fromEdge, occ)) return false;
   return true;
 }
 

--- a/src/shared/rendergraph/RenderGraph.cpp
+++ b/src/shared/rendergraph/RenderGraph.cpp
@@ -78,10 +78,7 @@ bool RenderGraph::isTerminus(const LineNode* n) {
 
     for (size_t p = 0; p < nf.edge->pl().getLines().size(); p++) {
       const LineOcc& lineOcc = nf.edge->pl().lineOccAtPos(p);
-      std::vector<Partner> partners = getPartners(n, nf.edge, lineOcc);
-      if (partners.size() == 0 &&
-          !LineGraph::lineContinuesByReversing(n, nf.edge, lineOcc))
-        return true;
+      if (LineGraph::terminatesAt(nf.edge, n, lineOcc.line)) return true;
     }
   }
   return false;

--- a/src/transitmap/tests/TerminusReverseTest.cpp
+++ b/src/transitmap/tests/TerminusReverseTest.cpp
@@ -89,4 +89,10 @@ void TerminusReverseTest::run() {
   TEST(shared::linegraph::LineGraph::terminatesAt(ab, a, &line), ==, true);
   TEST(shared::linegraph::LineGraph::terminatesAt(bc, c, &line), ==, false);
   TEST(shared::linegraph::LineGraph::terminatesAt(bd, d, &line), ==, true);
+
+  bd->pl().addLine(&line, b);
+
+  TEST(shared::linegraph::LineGraph::terminatesAt(ab, a, &line), ==, true);
+  TEST(shared::linegraph::LineGraph::terminatesAt(bd, d, &line), ==, true);
+  TEST(RenderGraph::isTerminus(d), ==, true);
 }


### PR DESCRIPTION
## Summary
- require a same-line continuation at the candidate terminus before treating a reversal as a through service
- reorder terminus detection to prefer local continuations and reuse it from the render graph terminus check
- extend the terminus reversal test to cover a bidirectional branch

## Testing
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Release *(fails: missing cppgtfs submodule due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68cae0872f1c832dadfbef5f56f2fbf3