### PR TITLE
Handle per-direction route occurrences

### DIFF
--- a/src/gtfs2graph/graph/EdgePL.cpp
+++ b/src/gtfs2graph/graph/EdgePL.cpp
@@ -74,8 +74,7 @@ void EdgePL::addEdgeTripGeom(const EdgeTripGeom& e) {
   assert(e.getGeomDir() == _e->getFrom() || e.getGeomDir() == _e->getTo());
 
   for (const auto& to : e.getTripsUnordered()) {
-    assert(to.direction == 0 || to.direction == _e->getFrom() ||
-           to.direction == _e->getTo());
+    assert(to.direction == _e->getFrom() || to.direction == _e->getTo());
   }
 
   _tripsContained.push_back(e);
@@ -190,9 +189,7 @@ util::json::Dict EdgePL::getAttrs() const {
     route["label"] = r.route->getShortName();
     route["color"] = r.route->getColorString();
 
-    if (r.direction != 0) {
-      route["direction"] = util::toString(r.direction);
-    }
+    route["direction"] = util::toString(r.direction);
 
     lines.push_back(route);
   }

--- a/src/gtfs2graph/graph/EdgeTripGeom.cpp
+++ b/src/gtfs2graph/graph/EdgeTripGeom.cpp
@@ -32,9 +32,9 @@ void EdgeTripGeom::addTrip(gtfs::Trip* t, const Node* dirNode,
 
 // _____________________________________________________________________________
 void EdgeTripGeom::addTrip(gtfs::Trip* t, const Node* dirNode) {
-  RouteOccurance* to = getRouteOcc(t->getRoute());
+  RouteOccurance* to = getRouteOcc(t->getRoute(), dirNode);
   if (!to) {
-    _routeOccs.push_back(RouteOccurance(t->getRoute()));
+    _routeOccs.push_back(RouteOccurance(t->getRoute(), dirNode));
     to = &_routeOccs.back();
   }
   to->addTrip(t, dirNode);
@@ -48,6 +48,16 @@ const std::vector<RouteOccurance>& EdgeTripGeom::getTripsUnordered() const {
 // _____________________________________________________________________________
 std::vector<RouteOccurance>* EdgeTripGeom::getTripsUnordered() {
   return &_routeOccs;
+}
+
+// _____________________________________________________________________________
+RouteOccurance* EdgeTripGeom::getRouteOcc(const gtfs::Route* r,
+                                          const Node* dirNode) const {
+  for (size_t i = 0; i < _routeOccs.size(); i++) {
+    RouteOccurance* to = const_cast<RouteOccurance*>(&_routeOccs[i]);
+    if (to->route == r && to->direction == dirNode) return to;
+  }
+  return 0;
 }
 
 // _____________________________________________________________________________

--- a/src/gtfs2graph/graph/EdgeTripGeom.h
+++ b/src/gtfs2graph/graph/EdgeTripGeom.h
@@ -5,6 +5,7 @@
 #ifndef GTFS2GRAPH_GRAPH_EDGETRIPGEOM_H_
 #define GTFS2GRAPH_GRAPH_EDGETRIPGEOM_H_
 
+#include <cassert>
 #include <vector>
 #include "ad/cppgtfs/gtfs/Route.h"
 #include "ad/cppgtfs/gtfs/Trip.h"
@@ -15,18 +16,15 @@ namespace gtfs2graph {
 namespace graph {
 
 struct RouteOccurance {
-  RouteOccurance(ad::cppgtfs::gtfs::Route* r) : route(r), direction(0) {}
+  RouteOccurance(ad::cppgtfs::gtfs::Route* r, const Node* dir)
+      : route(r), direction(dir) {}
   void addTrip(ad::cppgtfs::gtfs::Trip* t, const Node* dirNode) {
-    if (trips.size() == 0) {
-      direction = dirNode;
-    } else {
-      if (direction && direction != dirNode) direction = 0;
-    }
+    assert(direction == dirNode);
     trips.push_back(t);
   }
   ad::cppgtfs::gtfs::Route* route;
   std::vector<ad::cppgtfs::gtfs::Trip*> trips;
-  const Node* direction;  // 0 if in both directions
+  const Node* direction;
 };
 
 typedef std::pair<RouteOccurance*, size_t> TripOccWithPos;
@@ -44,6 +42,9 @@ class EdgeTripGeom {
 
   std::vector<RouteOccurance>::iterator removeRouteOcc(
       std::vector<RouteOccurance>::const_iterator pos);
+
+  RouteOccurance* getRouteOcc(const ad::cppgtfs::gtfs::Route* r,
+                              const Node* dirNode) const;
 
   RouteOccurance* getRouteOcc(const ad::cppgtfs::gtfs::Route* r) const;
 

--- a/src/gtfs2graph/graph/NodePL.cpp
+++ b/src/gtfs2graph/graph/NodePL.cpp
@@ -117,10 +117,11 @@ util::json::Dict NodePL::getAttrs() const {
         if (e == f) continue;
         if (!f->pl().getRefETG()) continue;
         for (auto rr : *f->pl().getRefETG()->getTripsUnordered()) {
+          bool rArrivesHere = r.direction == _n;
+          bool rrArrivesHere = rr.direction == _n;
           if (r.route == rr.route &&
-              (r.direction == 0 || rr.direction == 0 ||
-               (r.direction == _n && rr.direction != _n) ||
-               (r.direction != _n && rr.direction == _n)) &&
+              ((rArrivesHere && !rrArrivesHere) ||
+               (!rArrivesHere && rrArrivesHere)) &&
               !isConnOccuring(r.route, e, f)) {
             auto obj = util::json::Dict();
             obj["line"] = util::toString(r.route);

--- a/src/gtfs2graph/tests/TestMain.cpp
+++ b/src/gtfs2graph/tests/TestMain.cpp
@@ -1,12 +1,154 @@
 // Copyright 2016
 // Author: Patrick Brosi
 
+#include <fstream>
+#include <set>
+#include <string>
+
+#include "ad/cppgtfs/Parser.h"
+#include "ad/cppgtfs/gtfs/Feed.h"
+#include "ad/cppgtfs/gtfs/Route.h"
+#include "ad/cppgtfs/gtfs/flat/Route.h"
+#include "gtfs2graph/builder/Builder.h"
+#include "gtfs2graph/config/GraphBuilderConfig.h"
+#include "gtfs2graph/graph/BuildGraph.h"
+#include "gtfs2graph/graph/EdgePL.h"
+#include "gtfs2graph/graph/NodePL.h"
 #include "util/Misc.h"
+#include "util/String.h"
+#include "util/json/Writer.h"
+
+namespace {
+
+void writeGtfsFile(const std::string& baseDir, const std::string& name,
+                   const std::string& content) {
+  std::ofstream out(baseDir + "/" + name, std::ios::out | std::ios::trunc);
+  TEST(out.good());
+  out << content;
+  TEST(out.good());
+}
+
+bool nodeHasStop(const gtfs2graph::graph::Node* node,
+                 const std::string& stopId) {
+  for (const auto stop : node->pl().getStops()) {
+    if (stop->getId() == stopId) return true;
+  }
+  return false;
+}
+
+}  // namespace
 
 // _____________________________________________________________________________
 int main(int argc, char** argv) {
   UNUSED(argc);
   UNUSED(argv);
+
+  char tmpTemplate[] = "/tmp/gtfsXXXXXX";
+  char* dirName = mkdtemp(tmpTemplate);
+  TEST(dirName != nullptr);
+  std::string baseDir(dirName);
+
+  writeGtfsFile(baseDir, "agency.txt",
+                "agency_id,agency_name,agency_url,agency_timezone\n"
+                "AG,Agency,http://example.com,Europe/Berlin\n");
+  writeGtfsFile(baseDir, "routes.txt",
+                "route_id,agency_id,route_short_name,route_long_name,route_type\n"
+                "R1,AG,1,Sample Route,3\n");
+  writeGtfsFile(baseDir, "trips.txt",
+                "route_id,service_id,trip_id\n"
+                "R1,WK,TRIP1\n");
+  writeGtfsFile(baseDir, "stop_times.txt",
+                "trip_id,arrival_time,departure_time,stop_id,stop_sequence\n"
+                "TRIP1,08:00:00,08:00:00,STOP_A,1\n"
+                "TRIP1,08:05:00,08:05:00,STOP_B,2\n"
+                "TRIP1,08:10:00,08:10:00,STOP_C,3\n"
+                "TRIP1,08:15:00,08:15:00,STOP_B,4\n"
+                "TRIP1,08:20:00,08:20:00,STOP_D,5\n");
+  writeGtfsFile(baseDir, "stops.txt",
+                "stop_id,stop_name,stop_lat,stop_lon\n"
+                "STOP_A,A,0.0,0.0\n"
+                "STOP_B,B,0.1,0.0\n"
+                "STOP_C,C,0.1,0.1\n"
+                "STOP_D,D,0.0,0.1\n");
+  writeGtfsFile(baseDir, "calendar.txt",
+                "service_id,monday,tuesday,wednesday,thursday,friday,saturday,sunday,start_date,end_date\n"
+                "WK,1,1,1,1,1,0,0,20220101,20221231\n");
+
+  ad::cppgtfs::gtfs::Feed feed;
+  ad::cppgtfs::Parser parser(baseDir);
+  parser.parse(&feed);
+
+  gtfs2graph::config::Config cfg;
+  cfg.pruneThreshold = 0.0;
+  for (auto mot :
+       ad::cppgtfs::gtfs::flat::Route::getTypesFromString("bus")) {
+    cfg.useMots.insert(mot);
+  }
+
+  gtfs2graph::Builder builder(&cfg);
+  gtfs2graph::graph::BuildGraph graph;
+  builder.consume(feed, &graph);
+  builder.simplify(&graph);
+
+  const gtfs2graph::graph::Node* nodeB = nullptr;
+  const gtfs2graph::graph::Node* nodeC = nullptr;
+  for (auto node : graph.getNds()) {
+    if (!nodeB && nodeHasStop(node, "STOP_B")) nodeB = node;
+    if (!nodeC && nodeHasStop(node, "STOP_C")) nodeC = node;
+  }
+
+  TEST(nodeB != nullptr);
+  TEST(nodeC != nullptr);
+
+  const gtfs2graph::graph::Edge* bcEdge = nullptr;
+  for (auto node : graph.getNds()) {
+    for (auto edge : node->getAdjList()) {
+      bool connectsB = nodeHasStop(edge->getFrom(), "STOP_B") ||
+                       nodeHasStop(edge->getTo(), "STOP_B");
+      bool connectsC = nodeHasStop(edge->getFrom(), "STOP_C") ||
+                       nodeHasStop(edge->getTo(), "STOP_C");
+      if (connectsB && connectsC) {
+        bcEdge = edge;
+        break;
+      }
+    }
+    if (bcEdge) break;
+  }
+
+  TEST(bcEdge != nullptr);
+
+  auto attrs = bcEdge->pl().getAttrs();
+  auto linesIt = attrs.find("lines");
+  TEST(linesIt != attrs.end());
+  const auto& linesVal = linesIt->second;
+  TEST(linesVal.type, ==, util::json::Val::ARRAY);
+  TEST(linesVal.arr.size(), ==, 2u);
+
+  std::string expectedRouteId;
+  std::set<std::string> directions;
+  for (const auto& entry : linesVal.arr) {
+    TEST(entry.type, ==, util::json::Val::DICT);
+    const auto& dict = entry.dict;
+    auto idIt = dict.find("id");
+    TEST(idIt != dict.end());
+    TEST(idIt->second.type, ==, util::json::Val::STRING);
+    if (expectedRouteId.empty()) {
+      expectedRouteId = idIt->second.str;
+    } else {
+      TEST(idIt->second.str, ==, expectedRouteId);
+    }
+
+    auto dirIt = dict.find("direction");
+    TEST(dirIt != dict.end());
+    TEST(dirIt->second.type, ==, util::json::Val::STRING);
+    directions.insert(dirIt->second.str);
+  }
+
+  TEST(directions.size(), ==, 2u);
+  std::string nodeBId = util::toString(nodeB);
+  std::string nodeCId = util::toString(nodeC);
+  TEST(directions.count(nodeBId), ==, 1u);
+  TEST(directions.count(nodeCId), ==, 1u);
 
   return 0;
 }


### PR DESCRIPTION
## Summary
- key route occurrences on both route id and direction node so each entry tracks a single endpoint
- expose per-direction records through edge attributes and turn-connection logic so bidirectional service remains discoverable
- add a regression test that builds a small GTFS sample and checks the exported edge metadata lists both direction node ids

## Testing
- cmake -S . -B build *(fails: missing src/cppgtfs submodule in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb58f22cc4832db568e696c6ad355a