### PR TITLE
Ensure reversal logic preserves terminal stops

### DIFF
--- a/src/shared/linegraph/LineGraph.cpp
+++ b/src/shared/linegraph/LineGraph.cpp
@@ -1222,17 +1222,15 @@ bool LineGraph::lineContinuesByReversing(const LineNode* nd,
   if (!edge || !lo.line) return false;
   if (lo.direction != 0) return false;
 
-  bool hasContinuationAtTerminus = false;
+  bool hasAlternateSameLine = false;
   for (const auto* candidate : nd->getAdjList()) {
     if (candidate == edge) continue;
     if (!candidate->pl().hasLine(lo.line)) continue;
-    if (lineCtd(edge, candidate, lo.line)) {
-      hasContinuationAtTerminus = true;
-      break;
-    }
+    hasAlternateSameLine = true;
+    break;
   }
 
-  if (!hasContinuationAtTerminus) return false;
+  if (!hasAlternateSameLine) return false;
 
   const LineNode* other = edge->getOtherNd(nd);
   if (!other || other == nd) return false;
@@ -1312,13 +1310,16 @@ bool LineGraph::terminatesAt(const LineEdge* fromEdge, const LineNode* terminus,
                              const Line* line) {
   if (!fromEdge->pl().hasLine(line)) return false;
   const LineOcc& occ = fromEdge->pl().lineOcc(line);
+  bool hasAlternateSameLine = false;
   for (const auto& toEdg : terminus->getAdjList()) {
     if (toEdg == fromEdge) continue;
     if (!toEdg->pl().hasLine(line)) continue;
+    hasAlternateSameLine = true;
     if (lineCtd(fromEdge, toEdg, line)) {
       return false;
     }
   }
+  if (!hasAlternateSameLine) return true;
   if (lineContinuesByReversing(terminus, fromEdge, occ)) return false;
   return true;
 }

--- a/src/transitmap/tests/TerminusReverseTest.cpp
+++ b/src/transitmap/tests/TerminusReverseTest.cpp
@@ -92,7 +92,10 @@ void TerminusReverseTest::run() {
 
   bd->pl().addLine(&line, b);
 
+  // With the line running A→B→C→B→D, both terminal stops stay highlighted
+  // and must still report terminus status via the line graph helper.
   TEST(shared::linegraph::LineGraph::terminatesAt(ab, a, &line), ==, true);
   TEST(shared::linegraph::LineGraph::terminatesAt(bd, d, &line), ==, true);
+  TEST(RenderGraph::isTerminus(a), ==, true);
   TEST(RenderGraph::isTerminus(d), ==, true);
 }


### PR DESCRIPTION
## Summary
- prevent `lineContinuesByReversing` from treating single-connection stops as reversible continuations and short-circuit `terminatesAt` when no alternate same-line edges exist
- extend `TerminusReverseTest` with an A→B→C→B→D scenario to verify both ends remain termini in the render graph

## Testing
- cmake -S . -B build *(fails: missing cppgtfs submodule in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb621e27c8832da140acf596be204e