### PR TITLE
Fix neighbor edge constness in station crowd context

### DIFF
--- a/src/transitmap/label/Labeller.cpp
+++ b/src/transitmap/label/Labeller.cpp
@@ -557,8 +557,10 @@ Labeller::StationCrowdContext Labeller::computeStationFarCrowd(
     return ctx;
   }
 
-  ctx.neighborEdges = g.getNeighborEdges(band[0], searchRadius);
-  for (auto edge : ctx.neighborEdges) {
+  auto neighborEdges = g.getNeighborEdges(band[0], searchRadius);
+  ctx.neighborEdges.insert(neighborEdges.begin(), neighborEdges.end());
+
+  for (const auto *edge : ctx.neighborEdges) {
     if (!edge) continue;
     ctx.neighborNodes.insert(edge->getFrom());
     ctx.neighborNodes.insert(edge->getTo());
@@ -583,7 +585,7 @@ Labeller::StationCrowdContext Labeller::computeStationFarCrowd(
   double radius = _cfg->stationLabelFarCrowdRadius;
   int farCrowdCount = 0;
 
-  for (auto edge : ctx.neighborEdges) {
+  for (const auto *edge : ctx.neighborEdges) {
     if (!edge || edge->getFrom() == stationNode || edge->getTo() == stationNode)
       continue;
     double width = g.getTotalWidth(edge) / 2.0;


### PR DESCRIPTION
## Summary
- copy neighbor edges from the render graph into the station crowd context as const pointers
- iterate over neighbor edges with const-qualified pointers to respect the stored type

## Testing
- cmake -S . -B build *(fails: missing src/cppgtfs/CMakeLists.txt as in upstream configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68cb697e03c4832d9c6dd78b4bf1e7bb