### PR TITLE
Adjust SVG outline stroke width to match render spacing

### DIFF
--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -1344,7 +1344,8 @@ void SvgRenderer::renderLinePart(const PolyLine<double> p, double width,
                                  const std::string &oCss) {
   std::stringstream styleOutline;
   styleOutline << "fill:none;stroke:#000000;stroke-linecap:round;stroke-width:"
-               << (width + _cfg->outlineWidth) * _cfg->outputResolution << ";"
+               << (width + 2 * _cfg->outlineWidth) * _cfg->outputResolution
+               << ";"
                << oCss;
   Params paramsOutline;
   paramsOutline["style"] = styleOutline.str();


### PR DESCRIPTION
## Summary
- adjust the outline stroke-width calculation in `SvgRenderer::renderLinePart` to use `(width + 2 * outlineWidth) * outputResolution`

## Testing
- not run (visual inspection required outside headless environment)


------
https://chatgpt.com/codex/tasks/task_e_68cb6bc9f744832d96af9a0c67e881e0