### PR TITLE
Sort terminus label lines deterministically

### DIFF
--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -16,6 +16,7 @@
 #include <regex>
 #include <set>
 #include <unordered_map>
+#include <unordered_set>
 #include <sstream>
 #include <vector>
 
@@ -2045,17 +2046,25 @@ void SvgRenderer::renderTerminusLabels(const RenderGraph &g,
   }
 
   for (auto n : g.getNds()) {
-    std::set<const Line *> lines;
-    std::set<const Line *> seen;
+    std::vector<const Line *> lines;
+    std::unordered_set<const Line *> seen;
     for (auto e : n->getAdjList()) {
       for (const auto &lo : e->pl().getLines()) {
         if (seen.insert(lo.line).second && g.lineTerminatesAt(n, lo.line)) {
-          lines.insert(lo.line);
+          lines.push_back(lo.line);
         }
       }
     }
     if (lines.empty())
       continue;
+
+    std::sort(lines.begin(), lines.end(), [](const Line *lhs, const Line *rhs) {
+      if (lhs->label() != rhs->label())
+        return lhs->label() < rhs->label();
+      if (lhs->color() != rhs->color())
+        return lhs->color() < rhs->color();
+      return lhs->id() < rhs->id();
+    });
 
     double nodeX = n->pl().getGeom()->getX();
     double nodeY = n->pl().getGeom()->getY();


### PR DESCRIPTION
## Summary
- collect terminus line pointers into a vector so they can be sorted deterministically
- order badges by line label with color and id tie-breakers to ensure stable rendering

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb6bc982b8832d90e912b05bed5c4c