### PR TITLE
Fix LabellerOverlapTestAccess namespace

### DIFF
--- a/src/transitmap/tests/LabelPenaltyTest.cpp
+++ b/src/transitmap/tests/LabelPenaltyTest.cpp
@@ -23,17 +23,22 @@ using shared::linegraph::LineEdgePL;
 using shared::rendergraph::RenderGraph;
 using shared::linegraph::Station;
 
-namespace {
+namespace transitmapper::label {
 
 class LabellerOverlapTestAccess {
  public:
   static Overlaps getOverlaps(Labeller& labeller,
-                              const MultiLine<double>& band,
+                              const util::geo::MultiLine<double>& band,
                               const shared::linegraph::LineNode* node,
-                              const RenderGraph& g, double radius) {
+                              const shared::rendergraph::RenderGraph& g,
+                              double radius) {
     return labeller.getOverlaps(band, node, g, radius);
   }
 };
+
+}  // namespace transitmapper::label
+
+namespace {
 
 const shared::linegraph::LineNode* buildOverlapScenario(
     RenderGraph* g, std::vector<std::unique_ptr<Line>>* lines,
@@ -154,7 +159,7 @@ void LabelPenaltyTest::run() {
     MultiLine<double> overlapBand;
     auto* anchor = buildOverlapScenario(&g, &lines, &overlapBand);
     Labeller labeller(&cfg);
-    auto overlaps = LabellerOverlapTestAccess::getOverlaps(
+    auto overlaps = transitmapper::label::LabellerOverlapTestAccess::getOverlaps(
         labeller, overlapBand, anchor, g, 150.0);
     TEST(overlaps.lineOverlaps, ==, 2);
   }
@@ -168,7 +173,7 @@ void LabelPenaltyTest::run() {
     MultiLine<double> overlapBand;
     auto* anchor = buildOverlapScenario(&g, &lines, &overlapBand);
     Labeller labeller(&cfg);
-    auto overlaps = LabellerOverlapTestAccess::getOverlaps(
+    auto overlaps = transitmapper::label::LabellerOverlapTestAccess::getOverlaps(
         labeller, overlapBand, anchor, g, 150.0);
     TEST(overlaps.lineOverlaps, ==, 4);
   }


### PR DESCRIPTION
## Summary
- place the LabellerOverlapTestAccess test helper in the transitmapper::label namespace to match Labeller's friend declaration
- update LabelPenaltyTest overlap checks to reference the namespaced helper

## Testing
- cmake --build build --target transitmap_dep *(fails: configuration requires missing src/cppgtfs submodule)*

------
https://chatgpt.com/codex/tasks/task_e_68cb6cff1eb4832da8c4c3e6749473d4