### PR TITLE
Prefer station label geometry for terminus anchors

### DIFF
--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -2179,10 +2179,10 @@ void SvgRenderer::renderTerminusLabels(const RenderGraph &g,
     }
 
     bool above = true;
-    if (hasFootprint) {
-      above = footprintCenterY > nodeY;
-    } else if (hasLabelGeom) {
+    if (hasLabelGeom) {
       above = labelCenterY > nodeY;
+    } else if (hasFootprint) {
+      above = footprintCenterY > nodeY;
     }
 
     double anchorX = nodeX;
@@ -2192,16 +2192,16 @@ void SvgRenderer::renderTerminusLabels(const RenderGraph &g,
 
     switch (_cfg->terminusLabelAnchor) {
     case TerminusLabelAnchor::StationLabel:
-      if (hasFootprint) {
-        anchorX = footprintCenterX;
-        anchorY = above ? footprintCenterY + footprintHalfHeight
-                        : footprintCenterY - footprintHalfHeight;
-        clearance = footprintHalfHeight;
-      } else if (hasLabelGeom) {
+      if (hasLabelGeom) {
         anchorX = labelCenterX;
         anchorY = above ? labelCenterY + labelVExtent
                         : labelCenterY - labelVExtent;
         clearance = labelVExtent;
+      } else if (hasFootprint) {
+        anchorX = footprintCenterX;
+        anchorY = above ? footprintCenterY + footprintHalfHeight
+                        : footprintCenterY - footprintHalfHeight;
+        clearance = footprintHalfHeight;
       }
       break;
     case TerminusLabelAnchor::StopFootprint:


### PR DESCRIPTION
## Summary
- derive terminus anchor orientation and placement from station label geometry when available
- fall back to stop footprints and default behaviour only when no station label data is present

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb846565f0832d8563ba820ad68b21