### PR TITLE
Anchor me badge to station label

### DIFF
--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -1154,118 +1154,6 @@ void SvgRenderer::renderMe(const RenderGraph &g, Labeller &labeller,
     double outerR = starPx / 2.0;
     double innerR = outerR * 0.5;
 
-    util::geo::DPoint anchorMap = anchorPt.p;
-
-    auto localToMapDelta = [&](double alongPx, double perpPx) {
-      double alongMap = alongPx / res;
-      double perpMap = perpPx / res;
-      double dx = alongMap * dirX + perpMap * dirY;
-      double dy = alongMap * dirY + perpMap * (-dirX);
-      return std::pair<double, double>(dx, dy);
-    };
-
-    std::vector<std::pair<double, double>> localPoints = {
-        {rectStartAlong, rectPerpTop},
-        {rectStartAlong + rectWidth, rectPerpTop},
-        {rectStartAlong + rectWidth, rectPerpTop + rectHeight},
-        {rectStartAlong, rectPerpTop + rectHeight},
-        {starCenterAlong - outerR, starCenterPerp - outerR},
-        {starCenterAlong + outerR, starCenterPerp - outerR},
-        {starCenterAlong + outerR, starCenterPerp + outerR},
-        {starCenterAlong - outerR, starCenterPerp + outerR},
-        {0.0, 0.0}};
-
-    double minDX = 0.0;
-    double maxDX = 0.0;
-    double minDY = 0.0;
-    double maxDY = 0.0;
-    for (const auto &pt : localPoints) {
-      auto delta = localToMapDelta(pt.first, pt.second);
-      minDX = std::min(minDX, delta.first);
-      maxDX = std::max(maxDX, delta.first);
-      minDY = std::min(minDY, delta.second);
-      maxDY = std::max(maxDY, delta.second);
-    }
-
-    double halfW = std::max(std::abs(minDX), std::abs(maxDX));
-    double halfH = std::max(std::abs(minDY), std::abs(maxDY));
-    if (!(halfW > 0)) {
-      halfW = (rectWidth / res) / 2.0;
-    }
-    if (!(halfH > 0)) {
-      halfH = (rectHeight / res) / 2.0;
-    }
-
-    util::geo::Box<double> renderBox(
-        util::geo::DPoint(rparams.xOff, rparams.yOff),
-        util::geo::DPoint(rparams.xOff + rparams.width / _cfg->outputResolution,
-                          rparams.yOff +
-                              rparams.height / _cfg->outputResolution));
-
-    auto makeHighlightBox = [&](const util::geo::DPoint &center) {
-      return util::geo::Box<double>(
-          util::geo::DPoint(center.getX() - halfW, center.getY() - halfH),
-          util::geo::DPoint(center.getX() + halfW, center.getY() + halfH));
-    };
-
-    std::vector<util::geo::Box<double>> usedBoxes;
-    std::set<const shared::linegraph::LineEdge *> processedEdges;
-    for (auto n : g.getNds()) {
-      for (const auto &poly : g.getStopGeoms(n, _cfg->tightStations, 32)) {
-        usedBoxes.push_back(
-            util::geo::extendBox(poly, util::geo::Box<double>()));
-      }
-      for (auto e : n->getAdjList()) {
-        if (processedEdges.insert(e).second) {
-          util::geo::Box<double> b = util::geo::extendBox(
-              e->pl().getPolyline().getLine(), util::geo::Box<double>());
-          b = util::geo::pad(b, g.getTotalWidth(e) / 2.0);
-          usedBoxes.push_back(b);
-        }
-      }
-    }
-
-    auto appendLabelBoxes = [&](const StationLabel &stationLabel) {
-      util::geo::Box<double> labelBox =
-          util::geo::extendBox(stationLabel.band, util::geo::Box<double>());
-      if (isValidBox(labelBox)) {
-        usedBoxes.push_back(labelBox);
-      }
-    };
-
-    for (const auto &stationLabel : labeller.getStationLabels()) {
-      if (&stationLabel == label) {
-        continue;
-      }
-      appendLabelBoxes(stationLabel);
-    }
-
-    auto intersectsUsed = [&](const util::geo::Box<double> &candidate) {
-      for (const auto &b : usedBoxes) {
-        if (util::geo::intersects(candidate, b)) {
-          return true;
-        }
-      }
-      return false;
-    };
-
-    util::geo::DPoint placedAnchor = anchorMap;
-    if (intersectsUsed(makeHighlightBox(placedAnchor))) {
-      double searchRadius =
-          _cfg->landmarkSearchRadius * std::max(halfW, halfH);
-      util::geo::DPoint candidate = findFreeLandmarkPosition(
-          anchorMap, halfW, halfH, renderBox, usedBoxes, searchRadius);
-      util::geo::Box<double> candidateBox = makeHighlightBox(candidate);
-      if (!intersectsUsed(candidateBox)) {
-        placedAnchor = candidate;
-      }
-    }
-
-    anchorMap = placedAnchor;
-    anchorXPx = (anchorMap.getX() - rparams.xOff) * res;
-    anchorYPx =
-        rparams.height - (anchorMap.getY() - rparams.yOff) * res;
-
     std::stringstream transform;
     transform << "translate(" << anchorXPx << " " << anchorYPx
               << ") rotate(" << angleDeg << ")";
@@ -1330,22 +1218,6 @@ void SvgRenderer::renderMe(const RenderGraph &g, Labeller &labeller,
        (!_cfg->highlightMeStationLabel || _meStationLabelVisual.isNull()));
   bool badgeMode = _cfg->meStationWithBg && showLabel;
   Landmark lm = getAdjustedMeLandmark(_cfg, starPx, badgeMode);
-  std::vector<util::geo::Box<double>> usedBoxes;
-  std::set<const shared::linegraph::LineEdge *> processedEdges;
-  for (auto n : g.getNds()) {
-    for (const auto &poly : g.getStopGeoms(n, _cfg->tightStations, 32)) {
-      usedBoxes.push_back(util::geo::extendBox(poly, util::geo::Box<double>()));
-    }
-    for (auto e : n->getAdjList()) {
-      if (processedEdges.insert(e).second) {
-        util::geo::Box<double> b = util::geo::extendBox(
-            e->pl().getPolyline().getLine(), util::geo::Box<double>());
-        b = util::geo::pad(b, g.getTotalWidth(e) / 2.0);
-        usedBoxes.push_back(b);
-      }
-    }
-  }
-
   std::pair<double, double> dims = {0.0, 0.0};
   if (showLabel) {
     dims = ::getLandmarkSizePx(lm, _cfg);
@@ -1370,86 +1242,14 @@ void SvgRenderer::renderMe(const RenderGraph &g, Labeller &labeller,
   double halfW = (boxWpx / _cfg->outputResolution) / 2.0;
   double halfH = (boxHpx / _cfg->outputResolution) / 2.0;
   util::geo::DPoint base = lm.coord;
-  util::geo::Box<double> renderBox(
-      util::geo::DPoint(rparams.xOff, rparams.yOff),
-      util::geo::DPoint(rparams.xOff + rparams.width / _cfg->outputResolution,
-                        rparams.yOff + rparams.height / _cfg->outputResolution));
-  double searchRadius =
-      _cfg->landmarkSearchRadius * std::max(halfW, halfH);
   auto makeLandmarkBox = [&](const util::geo::DPoint &center) {
     return util::geo::Box<double>(
         util::geo::DPoint(center.getX() - halfW, center.getY() - halfH),
         util::geo::DPoint(center.getX() + halfW, center.getY() + halfH));
   };
-  auto isValidBox = [](const util::geo::Box<double> &b) {
-    return b.getLowerLeft().getX() <= b.getUpperRight().getX() &&
-           b.getLowerLeft().getY() <= b.getUpperRight().getY();
-  };
-  util::geo::DPoint placed = findFreeLandmarkPosition(
-      base, halfW, halfH, renderBox, usedBoxes, searchRadius);
-  util::geo::Box<double> box = makeLandmarkBox(placed);
-  bool landmarkAdded = labeller.addLandmark(box);
-  if (!landmarkAdded) {
-    if (!_cfg->meStation.empty()) {
-      auto collectBlockingLabelBoxes =
-          [&](const util::geo::Box<double> &candidateBox) {
-            std::vector<util::geo::Box<double>> boxes;
-            if (!labeller.collidesWithLabels(candidateBox)) {
-              return boxes;
-            }
-            for (const auto &label : labeller.getStationLabels()) {
-              util::geo::Box<double> labelBox = util::geo::extendBox(
-                  label.band, util::geo::Box<double>());
-              if (!isValidBox(labelBox)) {
-                continue;
-              }
-              if (util::geo::intersects(candidateBox, labelBox)) {
-                boxes.push_back(labelBox);
-              }
-            }
-            return boxes;
-          };
-
-      util::geo::DPoint attemptPos = placed;
-      util::geo::Box<double> attemptBox = box;
-      while (true) {
-        auto blockingBoxes = collectBlockingLabelBoxes(attemptBox);
-        bool appendedObstacle = false;
-        for (const auto &labelBox : blockingBoxes) {
-          if (!isValidBox(labelBox)) {
-            continue;
-          }
-          bool alreadyPresent = std::any_of(
-              usedBoxes.begin(), usedBoxes.end(),
-              [&](const util::geo::Box<double> &existing) {
-                return existing == labelBox;
-              });
-          if (!alreadyPresent) {
-            usedBoxes.push_back(labelBox);
-            appendedObstacle = true;
-          }
-        }
-        if (!appendedObstacle) {
-          break;
-        }
-        attemptPos = findFreeLandmarkPosition(base, halfW, halfH, renderBox,
-                                              usedBoxes, searchRadius);
-        attemptBox = makeLandmarkBox(attemptPos);
-        if (labeller.addLandmark(attemptBox)) {
-          placed = attemptPos;
-          landmarkAdded = true;
-          box = attemptBox;
-          break;
-        }
-      }
-    }
-    if (!landmarkAdded) {
-      util::geo::Box<double> baseBox = makeLandmarkBox(base);
-      labeller.addLandmark(baseBox);
-      placed = base;
-      box = baseBox;
-    }
-  }
+  util::geo::Box<double> box = makeLandmarkBox(base);
+  labeller.addLandmark(box);
+  util::geo::DPoint placed = base;
 
   double x = (placed.getX() - rparams.xOff) * _cfg->outputResolution;
   double y =


### PR DESCRIPTION
## Summary
- keep the highlighted "me" badge at the computed label anchor instead of searching for a free offset location
- register the non-highlighted "me" badge directly at the landmark base point and render the badge/label without retry loops

## Testing
- `cmake -S . -B build` *(fails: missing cppgtfs submodule, repository access blocked in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d1faeca594832d8573cd6139489aaa