### PR TITLE
Preserve display text for me-station badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,10 +328,14 @@ When any side-specific padding is provided, unspecified sides default to `0`.
                       longitude by default).
 * `--me-size <size>`: star size (default `150`).
 * `--me-label`: add a "YOU ARE HERE" label.
-* `--me-station <name>`: mark current location by station label.
+* `--me-station <name>`: mark current location by station label. The value is
+  trimmed and preserved for display while a sanitized identifier is derived for
+  graph matching, so the badge keeps the user's punctuation and casing even
+  when a slugged station id is required behind the scenes.
 * `--me-with-bg[=<bool>]`: when `--me-station` is active, restyle the matched
   station label with a rounded horizontal badge and star; falls back to the
-  standalone badge when the label cannot be restyled.
+  standalone badge when the label cannot be restyled, using the display text
+  from `--me-station` rather than the sanitized slug.
 * `--me-bg-fill <color>`: badge fill color for the background behind the `--me`
   marker (default `#f5f5f5`).
 * `--me-bg-stroke <color>`: badge stroke color for the `--me` background

--- a/src/transitmap/TransitMapMain.cpp
+++ b/src/transitmap/TransitMapMain.cpp
@@ -70,12 +70,12 @@ int main(int argc, char **argv) {
   b.expandOverlappinFronts(&g);
   g.createMetaNodes();
 
-  if (!cfg.meStation.empty()) {
+  if (!cfg.meStationId.empty()) {
+    bool matchedStation = false;
     for (auto n : g.getNds()) {
       if (!n->pl().stops().size()) continue;
       const auto &st = n->pl().stops().front();
-      if (util::sanitizeStationLabel(st.name) ==
-          util::sanitizeStationLabel(cfg.meStation)) {
+      if (util::sanitizeStationLabel(st.name) == cfg.meStationId) {
         cfg.meLandmark.coord = st.pos;
         cfg.meLandmark.color = cfg.meStationFill;
         cfg.meLandmark.size = cfg.meStarSize;
@@ -84,8 +84,13 @@ int main(int argc, char **argv) {
           cfg.meLandmark.fontSize = cfg.meLabelSize;
         }
         cfg.renderMe = true;
+        matchedStation = true;
         break;
       }
+    }
+    if (!matchedStation && cfg.meStationWithBg) {
+      cfg.meLandmark.label = cfg.meStationLabel;
+      cfg.meLandmark.fontSize = cfg.meLabelSize;
     }
   }
 

--- a/src/transitmap/config/ConfigReader.cpp
+++ b/src/transitmap/config/ConfigReader.cpp
@@ -449,9 +449,14 @@ void applyOption(Config *cfg, int c, const std::string &arg,
     }
     break;
   }
-  case 43:
-    cfg->meStation = util::sanitizeStationLabel(arg.c_str());
+  case 43: {
+    std::string trimmed = util::trim(arg);
+    std::string sanitized = util::sanitizeStationLabel(trimmed);
+    cfg->meStation = sanitized;
+    cfg->meStationId = sanitized;
+    cfg->meStationLabel = trimmed;
     break;
+  }
   case 44:
     cfg->meStationFill = arg;
     cfg->meLandmark.color = cfg->meStationFill;

--- a/src/transitmap/config/TransitMapConfig.h
+++ b/src/transitmap/config/TransitMapConfig.h
@@ -155,6 +155,10 @@ struct Config {
   double displacementCooling = 0.9;
 
   std::string meStation;
+  // Sanitized identifier used for matching the "you are here" station.
+  std::string meStationId;
+  // Display text used when rendering the "you are here" badge.
+  std::string meStationLabel;
   std::string meStationFill = "#f00";
   std::string meStationBorder;
   bool meStationWithBg = false;

--- a/src/transitmap/label/Labeller.cpp
+++ b/src/transitmap/label/Labeller.cpp
@@ -546,9 +546,9 @@ Labeller::getStationLblBand(const shared::linegraph::LineNode *n,
   double h = fontSize * 0.75;
 
   double bandHeight = h;
-  if (_cfg && !_cfg->meStation.empty()) {
+  if (_cfg && !_cfg->meStationId.empty()) {
     std::string slug = util::sanitizeStationLabel(lbl);
-    if (slug == _cfg->meStation &&
+    if (slug == _cfg->meStationId &&
         (_cfg->meStationWithBg || _cfg->highlightMeStationLabel)) {
       double starSize = std::max(_cfg->meStarSize, 0.0);
       double starGap = starSize * 0.2;

--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -394,10 +394,14 @@ void SvgRenderer::print(const RenderGraph &outG) {
   }
   if (_cfg->renderMe) {
     double starPx = _cfg->meStarSize * _cfg->outputResolution;
-    bool highlightIntent = _cfg->highlightMeStationLabel && !_cfg->meStation.empty();
+    bool highlightIntent =
+        _cfg->highlightMeStationLabel && !_cfg->meStationId.empty();
     bool showLabel = _cfg->renderMeLabel || _cfg->meStationWithBg || highlightIntent;
     bool badgeMode = (_cfg->meStationWithBg || highlightIntent) && showLabel;
     Landmark meLm = getAdjustedMeLandmark(_cfg, starPx, badgeMode);
+    if (meLm.label.empty() && !_cfg->meStationLabel.empty()) {
+      meLm.label = _cfg->meStationLabel;
+    }
     double labelWpx = 0.0;
     double labelHpx = 0.0;
     if (showLabel) {
@@ -995,7 +999,7 @@ void SvgRenderer::renderMe(const RenderGraph &g, Labeller &labeller,
   double starPx = _cfg->meStarSize * _cfg->outputResolution;
   bool highlightAvailable = false;
   StationLabelVisual highlightInfo;
-  if (_cfg->highlightMeStationLabel && !_cfg->meStation.empty() &&
+  if (_cfg->highlightMeStationLabel && !_cfg->meStationId.empty() &&
       !_meStationLabelVisual.isNull()) {
     const StationLabelVisual &stored = _meStationLabelVisual.get();
     if (stored.label && !stored.pathId.empty()) {
@@ -1256,6 +1260,9 @@ void SvgRenderer::renderMe(const RenderGraph &g, Labeller &labeller,
        (!_cfg->highlightMeStationLabel || _meStationLabelVisual.isNull()));
   bool badgeMode = _cfg->meStationWithBg && showLabel;
   Landmark lm = getAdjustedMeLandmark(_cfg, starPx, badgeMode);
+  if (lm.label.empty() && !_cfg->meStationLabel.empty()) {
+    lm.label = _cfg->meStationLabel;
+  }
   std::pair<double, double> dims = {0.0, 0.0};
   if (showLabel) {
     dims = ::getLandmarkSizePx(lm, _cfg);
@@ -2088,7 +2095,8 @@ void SvgRenderer::renderStationLabels(const Labeller &labeller,
 
   size_t id = 0;
   const auto &labels = labeller.getStationLabels();
-  bool wantHighlight = _cfg->highlightMeStationLabel && !_cfg->meStation.empty();
+  bool wantHighlight =
+      _cfg->highlightMeStationLabel && !_cfg->meStationId.empty();
 
   for (const auto &label : labels) {
     auto textPath = label.geom;
@@ -2158,7 +2166,7 @@ void SvgRenderer::renderStationLabels(const Labeller &labeller,
     bool isMeLabel = false;
     if (wantHighlight && _meStationLabelVisual.isNull()) {
       std::string sanitized = util::sanitizeStationLabel(label.s.name);
-      if (sanitized == _cfg->meStation) {
+      if (sanitized == _cfg->meStationId) {
         StationLabelVisual info;
         info.label = &label;
         info.pathId = pathIds[id];

--- a/src/transitmap/tests/MeBadgeCollisionTest.cpp
+++ b/src/transitmap/tests/MeBadgeCollisionTest.cpp
@@ -62,6 +62,8 @@ void MeBadgeCollisionTest::run() {
 
   Config controlCfg = baseCfg;
   controlCfg.meStation.clear();
+  controlCfg.meStationId.clear();
+  controlCfg.meStationLabel.clear();
   controlCfg.meStationWithBg = false;
   controlCfg.highlightMeStationLabel = false;
   Labeller controlLabeller(&controlCfg);
@@ -70,6 +72,8 @@ void MeBadgeCollisionTest::run() {
 
   Config badgeCfg = baseCfg;
   badgeCfg.meStation = util::sanitizeStationLabel("Here");
+  badgeCfg.meStationId = badgeCfg.meStation;
+  badgeCfg.meStationLabel = "Here";
   badgeCfg.meStationWithBg = true;
   badgeCfg.highlightMeStationLabel = true;
   Labeller badgeLabeller(&badgeCfg);
@@ -117,7 +121,7 @@ void MeBadgeCollisionTest::run() {
 
   const StationLabel *meLabel = nullptr;
   for (const auto &lbl : solverLabeller.getStationLabels()) {
-    if (util::sanitizeStationLabel(lbl.s.name) == solverCfg.meStation) {
+    if (util::sanitizeStationLabel(lbl.s.name) == solverCfg.meStationId) {
       meLabel = &lbl;
       break;
     }

--- a/src/transitmap/tests/MeBadgeRotationTest.cpp
+++ b/src/transitmap/tests/MeBadgeRotationTest.cpp
@@ -36,6 +36,8 @@ void MeBadgeRotationTest::run() {
   cfg.highlightMeStationLabel = true;
   cfg.meStationWithBg = true;
   cfg.meStation = "here";
+  cfg.meStationId = "here";
+  cfg.meStationLabel = "Here";
   cfg.meStarSize = 20.0;
   cfg.meStationBgFill = "#112233";
   cfg.meStationBgStroke = "#445566";

--- a/src/transitmap/tests/MeHighlightDisplacementTest.cpp
+++ b/src/transitmap/tests/MeHighlightDisplacementTest.cpp
@@ -41,6 +41,8 @@ void MeHighlightDisplacementTest::run() {
   cfg.highlightMeStationLabel = true;
   cfg.meStationWithBg = true;
   cfg.meStation = "here";
+  cfg.meStationId = "here";
+  cfg.meStationLabel = "Here";
   cfg.meStarSize = 20.0;
   cfg.meStationBgFill = "#112233";
   cfg.meStationBgStroke = "#445566";


### PR DESCRIPTION
## Summary
- extend the transit map config to track both a sanitized `--me-station` slug and the original display label
- update the reader, solver, and SVG renderer to match with the slug while rendering the preserved display text when badges or highlights fall back to manual labels
- refresh the unit tests and README documentation to cover the identifier vs. display text behaviour

## Testing
- cmake -S . -B build *(fails: missing src/cppgtfs CMakeLists from optional dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68d22b3f0f54832d8bef5cefa1781790