### PR TITLE
Add CLI flag to force rendering of me star

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,9 +325,13 @@ When any side-specific padding is provided, unspecified sides default to `0`.
 * `--landmarks-webmerc`: treat landmark and `--me` coordinates as already in
                           Web Mercator and skip conversion.
 * `--me <lat,lon>`: mark the given coordinates with a red star (latitude and
-                      longitude by default).
+  longitude by default).
 * `--me-size <size>`: star size (default `150`).
 * `--me-label`: add a "YOU ARE HERE" label.
+* `--me-star[=<bool>]`: force rendering of the "YOU ARE HERE" star when
+  coordinates or a matching station are provided without other `--me` toggles
+  (default `false`). The star inherits `--me-station-fill`, which defaults to
+  bright red (`#f00`).
 * `--me-station <name>`: mark current location by station label. The value is
   trimmed and preserved for display while a sanitized identifier is derived for
   graph matching, so the badge keeps the user's punctuation and casing even

--- a/src/transitmap/TransitMapMain.cpp
+++ b/src/transitmap/TransitMapMain.cpp
@@ -70,8 +70,9 @@ int main(int argc, char **argv) {
   b.expandOverlappinFronts(&g);
   g.createMetaNodes();
 
+  bool meCoordsProvided = cfg.renderMe;
+  bool matchedMeStation = false;
   if (!cfg.meStationId.empty()) {
-    bool matchedStation = false;
     for (auto n : g.getNds()) {
       if (!n->pl().stops().size()) continue;
       const auto &st = n->pl().stops().front();
@@ -84,14 +85,18 @@ int main(int argc, char **argv) {
           cfg.meLandmark.fontSize = cfg.meLabelSize;
         }
         cfg.renderMe = true;
-        matchedStation = true;
+        matchedMeStation = true;
         break;
       }
     }
-    if (!matchedStation && cfg.meStationWithBg) {
+    if (!matchedMeStation && cfg.meStationWithBg) {
       cfg.meLandmark.label = cfg.meStationLabel;
       cfg.meLandmark.fontSize = cfg.meLabelSize;
     }
+  }
+
+  if (cfg.forceMeStar && (meCoordsProvided || matchedMeStation)) {
+    cfg.renderMe = true;
   }
 
   // Attach landmarks.

--- a/src/transitmap/config/ConfigReader.cpp
+++ b/src/transitmap/config/ConfigReader.cpp
@@ -96,6 +96,7 @@ constexpr int OPT_TERMINUS_HIGHLIGHT_STROKE = 272;
 constexpr int OPT_STATION_LABEL_ANGLE_STEPS = 273;
 constexpr int OPT_STATION_LABEL_ANGLE_STEP_DEG = 274;
 constexpr int OPT_TERMINUS_ANGLE_PENALTY = 275;
+constexpr int OPT_ME_STAR = 276;
 bool toBool(const std::string &v) {
   std::string s = util::toLower(v);
   return s == "1" || s == "true" || s == "yes" || s == "on";
@@ -433,6 +434,13 @@ void applyOption(Config *cfg, int c, const std::string &arg,
       cfg->meLandmark.fontSize = cfg->meLabelSize;
     }
     break;
+  case OPT_ME_STAR: {
+    cfg->forceMeStar = arg.empty() ? true : toBool(arg);
+    if (cfg->forceMeStar) {
+      cfg->meLandmark.color = cfg->meStationFill;
+    }
+    break;
+  }
   case 39: {
     auto parts = util::split(arg, ',');
     if (parts.size() == 2) {
@@ -668,6 +676,8 @@ void ConfigReader::help(const char *bin) const {
       << "size of 'me' star\n"
       << std::setw(37) << "  --me-label"
       << "add 'YOU ARE HERE' text\n"
+      << std::setw(37) << "  --me-star[=<bool>]"
+      << "force rendering of 'me' star (default false, fill from --me-station-fill)\n"
       << std::setw(37) << "  --me-station arg"
       << "mark current location by station label\n"
       << std::setw(37) << "  --me-with-bg"
@@ -758,6 +768,7 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
       {"landmarks-webmerc", 54},
       {"me-size", 41},
       {"me-label", 42},
+      {"me-star", OPT_ME_STAR},
       {"me", 39},
       {"me-station", 43},
       {"me-with-bg", OPT_ME_WITH_BG},
@@ -916,6 +927,7 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
       {"landmarks-webmerc", no_argument, 0, 54},
       {"me-size", required_argument, 0, 41},
       {"me-label", no_argument, 0, 42},
+      {"me-star", optional_argument, 0, OPT_ME_STAR},
       {"me", required_argument, 0, 39},
       {"me-station", required_argument, 0, 43},
       {"me-with-bg", optional_argument, 0, OPT_ME_WITH_BG},

--- a/src/transitmap/config/TransitMapConfig.h
+++ b/src/transitmap/config/TransitMapConfig.h
@@ -23,6 +23,7 @@ enum class TerminusLabelAnchor {
 };
 
 struct Config {
+  Config() { meLandmark.color = meStationFill; }
   double lineWidth = 20;
   double lineSpacing = 10;
 
@@ -168,6 +169,7 @@ struct Config {
   std::string meStationTextColor = "#3a3a3a";
 
   bool renderMe = false;
+  bool forceMeStar = false;
   bool renderMeLabel = false;
   Landmark meLandmark;
 

--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -392,7 +392,7 @@ void SvgRenderer::print(const RenderGraph &outG) {
     box = util::geo::extendBox(lmBox, box);
     acceptedLandmarks.push_back(lm);
   }
-  if (_cfg->renderMe) {
+  if (_cfg->renderMe || _cfg->forceMeStar) {
     double starPx = _cfg->meStarSize * _cfg->outputResolution;
     bool highlightIntent =
         _cfg->highlightMeStationLabel && !_cfg->meStationId.empty();
@@ -590,7 +590,7 @@ void SvgRenderer::print(const RenderGraph &outG) {
     renderStationLabels(labeller, rparams);
   }
 
-  if (_cfg->renderMe) {
+  if (_cfg->renderMe || _cfg->forceMeStar) {
     renderMe(outG, labeller, rparams);
   }
 


### PR DESCRIPTION
## Summary
- add a `forceMeStar` toggle to the transit-map configuration and teach the CLI parser to handle `--me-star`
- propagate the toggle through TransitMapMain and the SVG renderer so the "you are here" star is drawn when explicitly requested
- document the new option and defaults in the README and command-line help text

## Testing
- `cmake -S . -B build` *(fails: missing src/cppgtfs CMakeLists from repo checkout)*

------
https://chatgpt.com/codex/tasks/task_e_68d22d89b678832db3164f03b73ba84d