### PR TITLE
Allow arrowheads without tails via config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Command-line parameters
 * `--line-spacing <px>`: spacing between transit lines (default `10`).
 * `--outline-width <px>`: width of line outlines (default `1`).
 * `--log-level <0..4>`: logging verbosity, `0`=errors to `4`=very verbose (default `2`).
-* `--render-dir-markers` and `--render-markers-tail`: render line direction markers and tails.
+* `--render-dir-markers`, `--render-markers-tail`, and `--render-head-without-tail`: render line direction markers, add tails, and keep arrowheads even when tails are disabled.
 * `--dir-marker-spacing <n>`: edges between forced direction markers (default `1`).
 * `--tail-ignore-sharp-angle`: ignore the sharp-angle check when rendering marker tails (default off).
 * `--bi-dir-marker`: render markers for bidirectional edges (default off).

--- a/loom.ini
+++ b/loom.ini
@@ -14,6 +14,7 @@ landmarks=../examples/landmarks_full.txt
 # outline-width=1
 # render-dir-markers=false
 # render-markers-tail=false
+# render-head-without-tail=true # keep arrowheads even if tails are suppressed
 # bi-dir-marker=false
 # crowded-line-thresh=3
 # sharp-turn-angle=0.785398

--- a/src/transitmap/config/ConfigReader.cpp
+++ b/src/transitmap/config/ConfigReader.cpp
@@ -97,6 +97,7 @@ constexpr int OPT_STATION_LABEL_ANGLE_STEPS = 273;
 constexpr int OPT_STATION_LABEL_ANGLE_STEP_DEG = 274;
 constexpr int OPT_TERMINUS_ANGLE_PENALTY = 275;
 constexpr int OPT_ME_STAR = 276;
+constexpr int OPT_RENDER_HEAD_WITHOUT_TAIL = 277;
 bool toBool(const std::string &v) {
   std::string s = util::toLower(v);
   return s == "1" || s == "true" || s == "yes" || s == "on";
@@ -253,6 +254,9 @@ void applyOption(Config *cfg, int c, const std::string &arg,
     break;
   case 20:
     cfg->renderMarkersTail = arg.empty() ? true : toBool(arg);
+    break;
+  case OPT_RENDER_HEAD_WITHOUT_TAIL:
+    cfg->renderHeadWithoutTail = arg.empty() ? true : toBool(arg);
     break;
   case 47:
     cfg->tailIgnoreSharpAngle = arg.empty() ? true : toBool(arg);
@@ -534,6 +538,8 @@ void ConfigReader::help(const char *bin) const {
       << "render line direction markers\n"
       << std::setw(37) << "  --render-markers-tail"
       << "add tail to direction markers\n"
+      << std::setw(37) << "  --render-head-without-tail"
+      << "keep arrowheads when tails are disabled\n"
       << std::setw(37) << "  --dir-marker-spacing arg (=1)"
       << "edges between forced direction markers\n"
       << std::setw(37) << "  --bi-dir-marker"
@@ -741,6 +747,7 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
       {"tight-stations", 9},
       {"render-dir-markers", 10},
       {"render-markers-tail", 20},
+      {"render-head-without-tail", OPT_RENDER_HEAD_WITHOUT_TAIL},
       {"dir-marker-spacing", 50},
       {"tail-ignore-sharp-angle", 47},
       {"no-render-node-connections", 11},
@@ -900,6 +907,8 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
       {"tight-stations", no_argument, 0, 9},
       {"render-dir-markers", no_argument, 0, 10},
       {"render-markers-tail", no_argument, 0, 20},
+      {"render-head-without-tail", no_argument, 0,
+       OPT_RENDER_HEAD_WITHOUT_TAIL},
       {"dir-marker-spacing", required_argument, 0, 50},
       {"tail-ignore-sharp-angle", no_argument, 0, 47},
       {"no-render-node-connections", no_argument, 0, 11},

--- a/src/transitmap/config/TransitMapConfig.h
+++ b/src/transitmap/config/TransitMapConfig.h
@@ -120,6 +120,7 @@ struct Config {
   bool renderDirMarkers = false;
   size_t dirMarkerSpacing = 1;
   bool renderMarkersTail = false;
+  bool renderHeadWithoutTail = true;
   bool tailIgnoreSharpAngle = false;
   bool renderBiDirMarker = false;
   size_t crowdedLineThresh = 3;

--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -1944,6 +1944,7 @@ void SvgRenderer::renderEdgeTripGeom(const RenderGraph &outG,
     double pLen = p.getLength();
     bool useTail = _cfg->renderMarkersTail && pLen > minLengthForTail &&
                    (_cfg->tailIgnoreSharpAngle || !sharpAngle);
+    bool allowHead = useTail || _cfg->renderHeadWithoutTail;
 
     std::string css, oCss;
 
@@ -1990,16 +1991,24 @@ void SvgRenderer::renderEdgeTripGeom(const RenderGraph &outG,
             PolyLine<double> tailToEnd = p.getSegmentAtDist(mid, tailEnd);
             renderLinePart(tailToStart, lineW, *line, "stroke:black",
                            "stroke:none");
-            renderArrowHead(tailToStart, lineW, false, true);
+            if (allowHead) {
+              renderArrowHead(tailToStart, lineW, false, true);
+            }
             renderLinePart(tailToEnd, lineW, *line, "stroke:black",
                            "stroke:none");
-            renderArrowHead(tailToEnd, lineW);
+            if (allowHead) {
+              renderArrowHead(tailToEnd, lineW);
+            }
           }
 
           renderLinePart(firstHalf, lineW, *line, css, oCss);
-          renderArrowHead(firstHalf, lineW, false, true);
+          if (allowHead) {
+            renderArrowHead(firstHalf, lineW, false, true);
+          }
           renderLinePart(secondHalf, lineW, *line, css, oCss);
-          renderArrowHead(secondHalf, lineW);
+          if (allowHead) {
+            renderArrowHead(secondHalf, lineW);
+          }
         } else if (lo.direction == e->getTo()) {
           if (useTail) {
             double tailStart = std::max(0.0, firstPart.getLength() - tailWorld);
@@ -2007,10 +2016,14 @@ void SvgRenderer::renderEdgeTripGeom(const RenderGraph &outG,
                 firstPart.getSegmentAtDist(tailStart, firstPart.getLength());
 
             renderLinePart(tail, lineW, *line, "stroke:black", "stroke:none");
-            renderArrowHead(tail, lineW);
+            if (allowHead) {
+              renderArrowHead(tail, lineW);
+            }
           }
           renderLinePart(firstPart, lineW, *line, css, oCss);
-          renderArrowHead(firstPart, lineW);
+          if (allowHead) {
+            renderArrowHead(firstPart, lineW);
+          }
           renderLinePart(revSecond, lineW, *line, css, oCss);
         } else {
           if (useTail) {
@@ -2018,10 +2031,14 @@ void SvgRenderer::renderEdgeTripGeom(const RenderGraph &outG,
             PolyLine<double> tail =
                 revSecond.getSegmentAtDist(tailStart, revSecond.getLength());
             renderLinePart(tail, lineW, *line, "stroke:black", "stroke:none");
-            renderArrowHead(tail, lineW);
+            if (allowHead) {
+              renderArrowHead(tail, lineW);
+            }
           }
           renderLinePart(revSecond, lineW, *line, css, oCss);
-          renderArrowHead(revSecond, lineW);
+          if (allowHead) {
+            renderArrowHead(revSecond, lineW);
+          }
           renderLinePart(firstPart, lineW, *line, css, oCss);
         }
       }


### PR DESCRIPTION
## Summary
- add a renderHeadWithoutTail flag to the runtime configuration and command line options
- guard SVG arrowhead rendering with the new flag and document the option for users

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5f6e41ac8832d96f7256e9903a0f5