### PR TITLE
Add option to hide single route terminus labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ Command-line parameters
   (`station-label`, `stop-footprint`, or `node`; default `station-label`).
 * `--compact-terminal-label`: arrange terminus route labels in multiple columns instead of a single row (default off).
 * `--compact-route-label`: stack edge route labels in multiple rows to avoid truncation (default off).
+* `--no-single-route-labels`: omit terminus route labels when only a single line stops at the station (default off).
 * `--highlight-terminal`: highlight terminus stations (default off).
 * `--terminus-highlight-fill <color>`: fill color when highlighting terminus stations (default `black`).
 * `--terminus-highlight-stroke <color>`: stroke color when highlighting terminus stations (default `#BAB6B6`).

--- a/src/transitmap/config/ConfigReader.cpp
+++ b/src/transitmap/config/ConfigReader.cpp
@@ -97,6 +97,7 @@ constexpr int OPT_STATION_LABEL_ANGLE_STEPS = 273;
 constexpr int OPT_STATION_LABEL_ANGLE_STEP_DEG = 274;
 constexpr int OPT_TERMINUS_ANGLE_PENALTY = 275;
 constexpr int OPT_ME_STAR = 276;
+constexpr int OPT_NO_SINGLE_ROUTE_LABELS = 277;
 bool toBool(const std::string &v) {
   std::string s = util::toLower(v);
   return s == "1" || s == "true" || s == "yes" || s == "on";
@@ -232,6 +233,9 @@ void applyOption(Config *cfg, int c, const std::string &arg,
     break;
   case 49:
     cfg->compactRouteLabel = arg.empty() ? true : toBool(arg);
+    break;
+  case OPT_NO_SINGLE_ROUTE_LABELS:
+    cfg->renderSingleRouteLabel = arg.empty() ? false : !toBool(arg);
     break;
   case 7:
     cfg->renderStations = arg.empty() ? false : !toBool(arg);
@@ -611,6 +615,8 @@ void ConfigReader::help(const char *bin) const {
       << "arrange terminus route labels in multiple columns\n"
       << std::setw(37) << "  --compact-route-label"
       << "stack route labels above edges in multiple rows\n"
+      << std::setw(37) << "  --no-single-route-labels"
+      << "omit route labels when only one line terminates\n"
       << std::setw(37) << "  --no-deg2-labels"
       << "no labels for deg-2 stations\n"
       << "Misc:\n"
@@ -735,6 +741,7 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
       {"terminus-highlight-stroke", OPT_TERMINUS_HIGHLIGHT_STROKE},
       {"compact-terminal-label", 48},
       {"compact-route-label", 49},
+      {"no-single-route-labels", OPT_NO_SINGLE_ROUTE_LABELS},
       {"no-render-stations", 7},
       {"labels", 'l'},
       {"route-labels", 'r'},
@@ -894,6 +901,7 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
        OPT_TERMINUS_HIGHLIGHT_STROKE},
       {"compact-terminal-label", no_argument, 0, 48},
       {"compact-route-label", no_argument, 0, 49},
+      {"no-single-route-labels", no_argument, 0, OPT_NO_SINGLE_ROUTE_LABELS},
       {"no-render-stations", no_argument, 0, 7},
       {"labels", no_argument, 0, 'l'},
       {"route-labels", no_argument, 0, 'r'},

--- a/src/transitmap/config/TransitMapConfig.h
+++ b/src/transitmap/config/TransitMapConfig.h
@@ -81,6 +81,8 @@ struct Config {
   bool compactTerminusLabel = false;
   // Stack route labels above edges into multiple rows when enabled.
   bool compactRouteLabel = false;
+  // Render route label stacks when only a single line terminates at a stop.
+  bool renderSingleRouteLabel = true;
 
   bool writeStats = false;
 

--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -2452,6 +2452,9 @@ void SvgRenderer::renderTerminusLabels(const RenderGraph &g,
     if (lines.empty())
       continue;
 
+    if (lines.size() == 1 && !_cfg->renderSingleRouteLabel)
+      continue;
+
     std::sort(lines.begin(), lines.end(), [](const Line *lhs, const Line *rhs) {
       if (lhs->label() != rhs->label())
         return lhs->label() < rhs->label();


### PR DESCRIPTION
## Summary
- add a configuration toggle to suppress single-line terminus route label stacks
- document the new option in the command line help and README
- skip rendering single-route terminus labels when the option is disabled

## Testing
- No automated tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5f9fdf54c832da09784ea5352d236