### PR TITLE
Skip single-route edge labels when disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ Command-line parameters
   (`station-label`, `stop-footprint`, or `node`; default `station-label`).
 * `--compact-terminal-label`: arrange terminus route labels in multiple columns instead of a single row (default off).
 * `--compact-route-label`: stack edge route labels in multiple rows to avoid truncation (default off).
-* `--no-single-route-labels`: omit terminus route labels when only a single line stops at the station (default off).
+* `--no-single-route-labels`: omit edge route labels when only a single line uses the segment (terminus stacks are still rendered; default off).
 * `--highlight-terminal`: highlight terminus stations (default off).
 * `--terminus-highlight-fill <color>`: fill color when highlighting terminus stations (default `black`).
 * `--terminus-highlight-stroke <color>`: stroke color when highlighting terminus stations (default `#BAB6B6`).

--- a/src/transitmap/config/TransitMapConfig.h
+++ b/src/transitmap/config/TransitMapConfig.h
@@ -81,7 +81,7 @@ struct Config {
   bool compactTerminusLabel = false;
   // Stack route labels above edges into multiple rows when enabled.
   bool compactRouteLabel = false;
-  // Render route label stacks when only a single line terminates at a stop.
+  // Render edge route labels when only a single line applies to the segment.
   bool renderSingleRouteLabel = true;
 
   bool writeStats = false;

--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -2199,6 +2199,9 @@ void SvgRenderer::renderStationLabels(const Labeller &labeller,
       _cfg->highlightMeStationLabel && !_cfg->meStationId.empty();
 
   for (const auto &label : labels) {
+    if (label.lines.size() == 1 && !_cfg->renderSingleRouteLabel)
+      continue;
+
     auto textPath = label.geom;
     double ang = util::geo::angBetween(textPath.front(), textPath.back());
 
@@ -2310,6 +2313,9 @@ void SvgRenderer::renderLineLabels(const Labeller &labeller,
   const auto &labels = labeller.getLineLabels();
 
   for (const auto &label : labels) {
+    if (label.lines.size() == 1 && !_cfg->renderSingleRouteLabel)
+      continue;
+
     auto textPath = label.geom;
     double ang = util::geo::angBetween(textPath.front(), textPath.back());
 
@@ -2351,6 +2357,9 @@ void SvgRenderer::renderLineLabels(const Labeller &labeller,
 
   id = 0;
   for (const auto &label : labels) {
+    if (label.lines.size() == 1 && !_cfg->renderSingleRouteLabel)
+      continue;
+
     auto textPath = label.geom;
     double ang = util::geo::angBetween(textPath.front(), textPath.back());
     double shift = 0.0;
@@ -2467,9 +2476,6 @@ void SvgRenderer::renderTerminusLabels(const RenderGraph &g,
       }
     }
     if (lines.empty())
-      continue;
-
-    if (lines.size() == 1 && !_cfg->renderSingleRouteLabel)
       continue;
 
     std::sort(lines.begin(), lines.end(), [](const Line *lhs, const Line *rhs) {


### PR DESCRIPTION
## Summary
- respect the renderSingleRouteLabel flag when emitting edge route labels so single-line segments can be skipped
- keep terminus route label stacks unaffected by the single-route setting and update configuration documentation accordingly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6111bb1dc832daa179093080324b9