### PR TITLE
Include served lines in station label metadata

### DIFF
--- a/src/transitmap/label/Labeller.cpp
+++ b/src/transitmap/label/Labeller.cpp
@@ -6,6 +6,7 @@
 #include <cctype>
 #include <cmath>
 #include <limits>
+#include <map>
 #include <numeric>
 #include <random>
 #include <set>
@@ -764,6 +765,20 @@ void Labeller::labelStations(const RenderGraph &g, bool notdeg2) {
     auto station = n->pl().stops().front();
     station.name = trimCopy(station.name);
 
+    std::map<std::string, const shared::linegraph::Line *> uniqueLines;
+    for (auto e : n->getAdjList()) {
+      for (const auto &lineOcc : e->getLines()) {
+        if (!lineOcc.line) continue;
+        uniqueLines.emplace(lineOcc.line->id(), lineOcc.line);
+      }
+    }
+
+    std::vector<const shared::linegraph::Line *> nodeLines;
+    nodeLines.reserve(uniqueLines.size());
+    for (const auto &entry : uniqueLines) {
+      nodeLines.push_back(entry.second);
+    }
+
     std::vector<StationLabelCandidate> cands;
 
     for (uint8_t offset = 0; offset < 3; offset++) {
@@ -841,7 +856,7 @@ void Labeller::labelStations(const RenderGraph &g, bool notdeg2) {
         bool opposite = sameSidePen > 0.0;
         StationLabelCandidate cand{
             StationLabel(PolyLine<double>(band[0]), band, fontSize, isTerminus,
-                         deg, offset, overlaps,
+                         nodeLines, deg, offset, overlaps,
                          sidePen + termPen + sameSidePen,
                          _cfg->stationLineOverlapPenalty, clusterPen,
                          farCrowdPen, outside,
@@ -1023,7 +1038,7 @@ void Labeller::labelStations(const RenderGraph &g, bool notdeg2) {
 
     StationLabel flipped(
         PolyLine<double>(flippedBand[0]), flippedBand, placed.fontSize,
-        placed.bold, flippedDeg, placed.pos, overlaps,
+        placed.bold, placed.lines, flippedDeg, placed.pos, overlaps,
         sidePen + termPen + sameSidePen, _cfg->stationLineOverlapPenalty,
         clusterPen, farCrowdPen, outside, _cfg->clusterPenScale,
         _cfg->outsidePenalty,
@@ -1224,8 +1239,9 @@ void Labeller::repositionStationLabels(const RenderGraph &g) {
                 : 0;
 
         StationLabel cand(
-            PolyLine<double>(band[0]), band, placed.fontSize, placed.bold, deg,
-            pos, overlaps, sidePen + termPen + sameSidePen,
+            PolyLine<double>(band[0]), band, placed.fontSize, placed.bold,
+            placed.lines, deg, pos, overlaps,
+            sidePen + termPen + sameSidePen,
             _cfg->stationLineOverlapPenalty, clusterPen, farCrowdPen, outside,
             _cfg->clusterPenScale, _cfg->outsidePenalty,
             &_cfg->orientationPenalties, placed.s);

--- a/src/transitmap/label/Labeller.h
+++ b/src/transitmap/label/Labeller.h
@@ -6,6 +6,7 @@
 #define TRANSITMAP_LABEL_LABELLER_H_
 
 #include <set>
+#include <vector>
 
 #include "shared/linegraph/Line.h"
 #include "shared/rendergraph/RenderGraph.h"
@@ -61,6 +62,8 @@ struct StationLabel {
   double fontSize;
   bool bold;
 
+  std::vector<const shared::linegraph::Line*> lines;
+
   size_t deg;
   size_t pos;
   Overlaps overlaps;
@@ -82,7 +85,8 @@ struct StationLabel {
 
   StationLabel(const util::geo::PolyLine<double>& geom,
                const util::geo::MultiLine<double>& band, double fontSize,
-               bool bold, size_t deg, size_t pos, const Overlaps& overlaps,
+               bool bold, std::vector<const shared::linegraph::Line*> lines,
+               size_t deg, size_t pos, const Overlaps& overlaps,
                double sidePen, double lineOverlapPenalty, double clusterPen,
                double farCrowdPen, bool outside, double clusterPenScale,
                double outsidePenalty,
@@ -92,6 +96,7 @@ struct StationLabel {
         band(band),
         fontSize(fontSize),
         bold(bold),
+        lines(std::move(lines)),
         deg(deg),
         pos(pos),
         overlaps(overlaps),


### PR DESCRIPTION
## Summary
- extend `StationLabel` with stored line references so metadata persists across copies
- collect and deduplicate the lines served by each node when creating station label candidates
- propagate the stored line information through label repositioning logic

## Testing
- `cmake -S . -B build` *(fails: missing src/cppgtfs/CMakeLists.txt in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d613e731a0832d8158d972c5213073