### PR TITLE
Fix station label line aggregation

### DIFF
--- a/src/transitmap/label/Labeller.h
+++ b/src/transitmap/label/Labeller.h
@@ -6,6 +6,7 @@
 #define TRANSITMAP_LABEL_LABELLER_H_
 
 #include <set>
+#include <vector>
 
 #include "shared/linegraph/Line.h"
 #include "shared/rendergraph/RenderGraph.h"
@@ -61,6 +62,8 @@ struct StationLabel {
   double fontSize;
   bool bold;
 
+  std::vector<const shared::linegraph::Line*> lines;
+
   size_t deg;
   size_t pos;
   Overlaps overlaps;
@@ -82,7 +85,8 @@ struct StationLabel {
 
   StationLabel(const util::geo::PolyLine<double>& geom,
                const util::geo::MultiLine<double>& band, double fontSize,
-               bool bold, size_t deg, size_t pos, const Overlaps& overlaps,
+               bool bold, std::vector<const shared::linegraph::Line*> lines,
+               size_t deg, size_t pos, const Overlaps& overlaps,
                double sidePen, double lineOverlapPenalty, double clusterPen,
                double farCrowdPen, bool outside, double clusterPenScale,
                double outsidePenalty,
@@ -92,6 +96,7 @@ struct StationLabel {
         band(band),
         fontSize(fontSize),
         bold(bold),
+        lines(std::move(lines)),
         deg(deg),
         pos(pos),
         overlaps(overlaps),

--- a/src/transitmap/tests/LabelPenaltyTest.cpp
+++ b/src/transitmap/tests/LabelPenaltyTest.cpp
@@ -91,29 +91,30 @@ void LabelPenaltyTest::run() {
 
   PolyLine<double> geom;
   MultiLine<double> band;
+  std::vector<const shared::linegraph::Line*> lines;
   Overlaps ov{0, 0, 0, 0, 0};
   Station st("id", "name", util::geo::DPoint());
 
   double sideA = 2 * cfgA.sidePenaltyWeight;
   double sideB = 2 * cfgB.sidePenaltyWeight;
 
-  StationLabel lblA(geom, band, 10, false, 0, 0, ov, sideA,
+  StationLabel lblA(geom, band, 10, false, lines, 0, 0, ov, sideA,
                     cfgA.stationLineOverlapPenalty, 0, 0, false,
                     cfgA.clusterPenScale, cfgA.outsidePenalty,
                     &cfgA.orientationPenalties, st);
-  StationLabel lblB(geom, band, 10, false, 0, 0, ov, sideB,
+  StationLabel lblB(geom, band, 10, false, lines, 0, 0, ov, sideB,
                     cfgB.stationLineOverlapPenalty, 0, 0, false,
                     cfgB.clusterPenScale, cfgB.outsidePenalty,
                     &cfgB.orientationPenalties, st);
   TEST(lblB.getPen() > lblA.getPen());
 
-  StationLabel lblC(geom, band, 10, false, 1, 0, ov, sideA,
+  StationLabel lblC(geom, band, 10, false, lines, 1, 0, ov, sideA,
                     cfgA.stationLineOverlapPenalty, 0, 0, false,
                     cfgA.clusterPenScale, cfgA.outsidePenalty,
                     &cfgA.orientationPenalties, st);
   TEST(lblC.getPen() > lblA.getPen());
 
-  StationLabel lblFar(geom, band, 10, false, 0, 0, ov, sideA,
+  StationLabel lblFar(geom, band, 10, false, lines, 0, 0, ov, sideA,
                       cfgA.stationLineOverlapPenalty, 0,
                       cfgA.stationLabelFarCrowdPenalty, false,
                       cfgA.clusterPenScale, cfgA.outsidePenalty,
@@ -125,11 +126,11 @@ void LabelPenaltyTest::run() {
   Config cfgD;
   cfgC.clusterPenScale = 1.0;
   cfgD.clusterPenScale = 5.0;
-  StationLabel lblD(geom, band, 10, false, 0, 0, ov, 0,
+  StationLabel lblD(geom, band, 10, false, lines, 0, 0, ov, 0,
                     cfgC.stationLineOverlapPenalty, 1.0, 0, false,
                     cfgC.clusterPenScale, cfgC.outsidePenalty,
                     &cfgC.orientationPenalties, st);
-  StationLabel lblE(geom, band, 10, false, 0, 0, ov, 0,
+  StationLabel lblE(geom, band, 10, false, lines, 0, 0, ov, 0,
                     cfgD.stationLineOverlapPenalty, 1.0, 0, false,
                     cfgD.clusterPenScale, cfgD.outsidePenalty,
                     &cfgD.orientationPenalties, st);
@@ -140,11 +141,11 @@ void LabelPenaltyTest::run() {
   Config cfgOutBon;
   cfgOutPen.outsidePenalty = 5.0;
   cfgOutBon.outsidePenalty = -5.0;
-  StationLabel lblOutPen(geom, band, 10, false, 0, 0, ov, 0,
+  StationLabel lblOutPen(geom, band, 10, false, lines, 0, 0, ov, 0,
                          cfgOutPen.stationLineOverlapPenalty, 0, 0, true,
                          cfgOutPen.clusterPenScale, cfgOutPen.outsidePenalty,
                          &cfgOutPen.orientationPenalties, st);
-  StationLabel lblOutBon(geom, band, 10, false, 0, 0, ov, 0,
+  StationLabel lblOutBon(geom, band, 10, false, lines, 0, 0, ov, 0,
                          cfgOutBon.stationLineOverlapPenalty, 0, 0, true,
                          cfgOutBon.clusterPenScale, cfgOutBon.outsidePenalty,
                          &cfgOutBon.orientationPenalties, st);

--- a/src/transitmap/tests/MeBadgeRotationTest.cpp
+++ b/src/transitmap/tests/MeBadgeRotationTest.cpp
@@ -1,6 +1,7 @@
 #include <cmath>
 #include <sstream>
 #include <string>
+#include <vector>
 
 #define private public
 #include "transitmap/output/SvgRenderer.h"
@@ -59,7 +60,8 @@ void MeBadgeRotationTest::run() {
 
   Overlaps overlaps{0, 0, 0, 0, 0};
   Station station("s1", "Here", DPoint(20.0, 20.0));
-  StationLabel label(geom, band, 20.0, false, 0, 0, overlaps, 0.0, 15.0, 0.0,
+  std::vector<const shared::linegraph::Line*> lines;
+  StationLabel label(geom, band, 20.0, false, lines, 0, 0, overlaps, 0.0, 15.0, 0.0,
                      0.0, false, 1.0, 0.0, nullptr, station);
 
   SvgRenderer::StationLabelVisual highlight;

--- a/src/transitmap/tests/MeHighlightDisplacementTest.cpp
+++ b/src/transitmap/tests/MeHighlightDisplacementTest.cpp
@@ -90,7 +90,8 @@ void MeHighlightDisplacementTest::run() {
 
   Overlaps overlaps{0, 0, 0, 0, 0};
   Station station("s1", "Here", DPoint(0.0, 0.0));
-  StationLabel label(geom, band, 20.0, false, 0, 0, overlaps, 0.0, 15.0, 0.0,
+  std::vector<const shared::linegraph::Line*> lines;
+  StationLabel label(geom, band, 20.0, false, lines, 0, 0, overlaps, 0.0, 15.0, 0.0,
                      0.0, false, 1.0, 0.0, nullptr, station);
 
   SvgRenderer::StationLabelVisual highlight;

--- a/src/transitmap/tests/StationFarCrowdTest.cpp
+++ b/src/transitmap/tests/StationFarCrowdTest.cpp
@@ -44,8 +44,9 @@ class LabellerFarCrowdTestAccess {
     Overlaps overlaps{0, 0, 0, 0, 0};
     shared::linegraph::Station st("synthetic", "synthetic",
                                   util::geo::DPoint());
+    std::vector<const shared::linegraph::Line*> lines;
     StationLabel label(util::geo::PolyLine<double>(band[0]), band, fontSize,
-                       false, 0, 0, overlaps, 0,
+                       false, lines, 0, 0, overlaps, 0,
                        labeller._cfg->stationLineOverlapPenalty, 0, 0, false,
                        labeller._cfg->clusterPenScale,
                        labeller._cfg->outsidePenalty, nullptr, st);

--- a/src/transitmap/tests/TerminusLabelPlacementTest.cpp
+++ b/src/transitmap/tests/TerminusLabelPlacementTest.cpp
@@ -130,8 +130,9 @@ void TerminusLabelPlacementTest::run() {
     Overlaps overlaps{0, 0, 0, 0, 0};
     Labeller labeller(&cfg);
     labeller._stationLabels.clear();
+    std::vector<const shared::linegraph::Line*> lines;
     labeller._stationLabels.emplace_back(
-        labelGeom, band, cfg.stationLabelSize, false, 0, 0, overlaps, 0.0,
+        labelGeom, band, cfg.stationLabelSize, false, lines, 0, 0, overlaps, 0.0,
         cfg.stationLineOverlapPenalty, 0.0, 0.0, false, 1.0, 0.0, nullptr,
         stop);
 


### PR DESCRIPTION
## Summary
- fix station line enumeration in the labeller to use the property list accessor
- update station label constructor usage in tests to provide the served line vector
- include missing headers needed for the new constructor arguments

## Testing
- `cmake -S . -B build` *(fails: missing src/cppgtfs/CMakeLists.txt)*

------
https://chatgpt.com/codex/tasks/task_e_68d613e731a0832d8158d972c5213073