### PR TITLE
Stream SVG geometry output for large backgrounds

### DIFF
--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -2109,17 +2109,37 @@ void SvgRenderer::printLine(const PolyLine<double> &l,
                             const std::map<std::string, std::string> &ps,
                             const RenderParams &rparams) {
   std::map<std::string, std::string> params = ps;
-  std::stringstream points;
+  params["points"];
 
-  for (auto &p : l.getLine()) {
-    points << " " << (p.getX() - rparams.xOff) * _cfg->outputResolution << ","
-           << rparams.height -
-                  (p.getY() - rparams.yOff) * _cfg->outputResolution;
+  _w.openTag("polyline");
+
+  auto emitAttribute = [this](const std::string &key,
+                              const std::string &value) {
+    _w.put(" ");
+    _w.putEsced(key, '"');
+    _w.put("=\"");
+    _w.putEsced(value, '"');
+    _w.put("\"");
+  };
+
+  for (const auto &kv : params) {
+    if (kv.first == "points") {
+      _w.put(" points=\"");
+      for (const auto &p : l.getLine()) {
+        _w.put(" ");
+        _w.put(util::toString((p.getX() - rparams.xOff) *
+                              _cfg->outputResolution));
+        _w.put(",");
+        _w.put(util::toString(rparams.height -
+                              (p.getY() - rparams.yOff) *
+                                  _cfg->outputResolution));
+      }
+      _w.put("\"");
+    } else {
+      emitAttribute(kv.first, kv.second);
+    }
   }
 
-  params["points"] = points.str();
-
-  _w.openTag("polyline", params);
   _w.closeTag();
 }
 
@@ -2128,19 +2148,40 @@ void SvgRenderer::printPolygon(const Polygon<double> &g,
                                const std::map<std::string, std::string> &ps,
                                const RenderParams &rparams) {
   std::map<std::string, std::string> params = ps;
-  std::stringstream points;
-
-  for (auto &p : g.getOuter()) {
-    points << " " << (p.getX() - rparams.xOff) * _cfg->outputResolution << ","
-           << rparams.height -
-                  (p.getY() - rparams.yOff) * _cfg->outputResolution;
-  }
-
-  params["points"] = points.str();
   if (!params.count("class")) {
     params["class"] = "station-poly";
   }
-  _w.openTag("polygon", params);
+  params["points"];
+
+  _w.openTag("polygon");
+
+  auto emitAttribute = [this](const std::string &key,
+                              const std::string &value) {
+    _w.put(" ");
+    _w.putEsced(key, '"');
+    _w.put("=\"");
+    _w.putEsced(value, '"');
+    _w.put("\"");
+  };
+
+  for (const auto &kv : params) {
+    if (kv.first == "points") {
+      _w.put(" points=\"");
+      for (const auto &p : g.getOuter()) {
+        _w.put(" ");
+        _w.put(util::toString((p.getX() - rparams.xOff) *
+                              _cfg->outputResolution));
+        _w.put(",");
+        _w.put(util::toString(rparams.height -
+                              (p.getY() - rparams.yOff) *
+                                  _cfg->outputResolution));
+      }
+      _w.put("\"");
+    } else {
+      emitAttribute(kv.first, kv.second);
+    }
+  }
+
   _w.closeTag();
 }
 

--- a/src/transitmap/tests/BgMapTest.cpp
+++ b/src/transitmap/tests/BgMapTest.cpp
@@ -1,5 +1,6 @@
 #include <fstream>
 #include <sstream>
+#include <stdexcept>
 #include <vector>
 
 #define private public
@@ -237,5 +238,33 @@ void BgMapTest::run() {
     defaultCount++;
   }
   TEST(defaultCount, ==, 2);
+
+  // Render a feature with a very large coordinate list and ensure streaming
+  // keeps memory bounded.
+  std::string hugePath = "bgmap_huge_line.geojson";
+  {
+    std::ofstream out(hugePath);
+    out << "{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"geometry\":{\"type\":\"LineString\",\"coordinates\":[";
+    const size_t numPoints = 200000;
+    for (size_t i = 0; i < numPoints; ++i) {
+      if (i)
+        out << ",";
+      out << "[" << (i % 1024) << "," << (i / 1024) << "]";
+    }
+    out << "]}}]}";
+  }
+
+  Config cfgHuge;
+  const char *argvHuge[] = {"prog", "--bg-map", hugePath.c_str()};
+  reader.read(&cfgHuge, 3, const_cast<char **>(argvHuge));
+  std::ostringstream svgHuge;
+  SvgRenderer sHuge(&svgHuge, &cfgHuge);
+  bool lengthErrorThrown = false;
+  try {
+    sHuge.print(g);
+  } catch (const std::length_error &) {
+    lengthErrorThrown = true;
+  }
+  TEST(lengthErrorThrown, ==, false);
 
 }


### PR DESCRIPTION
## Summary
- stream polyline and polygon coordinates directly through the XML writer to avoid building massive intermediate strings
- keep background rendering on the streaming path and add regression coverage for huge GeoJSON coordinate arrays

## Testing
- `cmake -S . -B build` *(fails: /workspace/loom/src/cppgtfs does not contain a CMakeLists.txt file)*

------
https://chatgpt.com/codex/tasks/task_e_68d62b7dc458832dbb05a84531c3e380