### PR TITLE
Enable direction marker tails by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Command-line parameters
 * `--line-spacing <px>`: spacing between transit lines (default `10`).
 * `--outline-width <px>`: width of line outlines (default `1`).
 * `--log-level <0..4>`: logging verbosity, `0`=errors to `4`=very verbose (default `2`).
-* `--render-dir-markers` and `--render-markers-tail`: render line direction markers and tails.
+* `--render-dir-markers`: render line direction markers (tails are always enabled when space allows).
 * `--dir-marker-spacing <n>`: edges between forced direction markers (default `1`).
 * `--tail-ignore-sharp-angle`: ignore the sharp-angle check when rendering marker tails (default off).
 * `--bi-dir-marker`: render markers for bidirectional edges (default off).

--- a/loom.ini
+++ b/loom.ini
@@ -1,7 +1,6 @@
 labels=true
 route-labels=true
 render-dir-markers=true
-render-markers-tail=true
 tl-ratio=2.1
 me-station=5 Шар /урд/
 me-station-fill=#ff0000
@@ -13,7 +12,7 @@ landmarks=../examples/landmarks_full.txt
 # line-spacing=10
 # outline-width=1
 # render-dir-markers=false
-# render-markers-tail=false
+# Direction marker tails are always enabled
 # bi-dir-marker=false
 # crowded-line-thresh=3
 # sharp-turn-angle=0.785398

--- a/run_transitmap.sh
+++ b/run_transitmap.sh
@@ -35,7 +35,7 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "$SCRIPT_PATH")" && pwd)"
 # Default args (match your one-liner)
 : "${TOPO_ARGS:="--smooth 1"}"
 : "${LOOM_ARGS:="--in-stat-cross-pen-diff-seg=4 --in-stat-cross-pen-same-seg=2 --in-stat-sep-pen=9 --same-seg-cross-pen=6 --diff-seg-cross-pen=1 --sep-pen=2"}"
-: "${TRANSITMAP_ARGS:="-l -r --render-dir-markers --render-markers-tail --highlight-terminal --tl-ratio=2.1 --compact-route-label --tail-ignore-sharp-angle --crowded-line-thresh=1 --dir-marker-spacing=2"}"
+: "${TRANSITMAP_ARGS:="-l -r --render-dir-markers --highlight-terminal --tl-ratio=2.1 --compact-route-label --tail-ignore-sharp-angle --crowded-line-thresh=1 --dir-marker-spacing=2"}"
 
 # ---------- help ----------
 show_help() {

--- a/src/transitmap/config/ConfigReader.cpp
+++ b/src/transitmap/config/ConfigReader.cpp
@@ -251,9 +251,6 @@ void applyOption(Config *cfg, int c, const std::string &arg,
   case 50:
     cfg->dirMarkerSpacing = atoi(arg.c_str());
     break;
-  case 20:
-    cfg->renderMarkersTail = arg.empty() ? true : toBool(arg);
-    break;
   case 47:
     cfg->tailIgnoreSharpAngle = arg.empty() ? true : toBool(arg);
     break;
@@ -532,8 +529,6 @@ void ConfigReader::help(const char *bin) const {
       << "width of line outlines\n"
       << std::setw(37) << "  --render-dir-markers"
       << "render line direction markers\n"
-      << std::setw(37) << "  --render-markers-tail"
-      << "add tail to direction markers\n"
       << std::setw(37) << "  --dir-marker-spacing arg (=1)"
       << "edges between forced direction markers\n"
       << std::setw(37) << "  --bi-dir-marker"
@@ -740,7 +735,6 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
       {"route-labels", 'r'},
       {"tight-stations", 9},
       {"render-dir-markers", 10},
-      {"render-markers-tail", 20},
       {"dir-marker-spacing", 50},
       {"tail-ignore-sharp-angle", 47},
       {"no-render-node-connections", 11},
@@ -899,7 +893,6 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
       {"route-labels", no_argument, 0, 'r'},
       {"tight-stations", no_argument, 0, 9},
       {"render-dir-markers", no_argument, 0, 10},
-      {"render-markers-tail", no_argument, 0, 20},
       {"dir-marker-spacing", required_argument, 0, 50},
       {"tail-ignore-sharp-angle", no_argument, 0, 47},
       {"no-render-node-connections", no_argument, 0, 11},

--- a/src/transitmap/config/TransitMapConfig.h
+++ b/src/transitmap/config/TransitMapConfig.h
@@ -119,7 +119,6 @@ struct Config {
 
   bool renderDirMarkers = false;
   size_t dirMarkerSpacing = 1;
-  bool renderMarkersTail = false;
   bool tailIgnoreSharpAngle = false;
   bool renderBiDirMarker = false;
   size_t crowdedLineThresh = 3;

--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -1942,7 +1942,7 @@ void SvgRenderer::renderEdgeTripGeom(const RenderGraph &outG,
     double minLengthForTail = arrowLength * 3 + tailWorld;
     bool sharpAngle = hasSharpAngle(e, center, line);
     double pLen = p.getLength();
-    bool useTail = _cfg->renderMarkersTail && pLen > minLengthForTail &&
+    bool useTail = pLen > minLengthForTail &&
                    (_cfg->tailIgnoreSharpAngle || !sharpAngle);
 
     std::string css, oCss;


### PR DESCRIPTION
## Summary
- always emit direction marker tails when geometry permits by removing the configuration guard
- drop the render-markers-tail configuration option from the CLI, default config, and helper script
- update documentation and sample configs to note that tails are now always enabled

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d654bf8134832d8ffe30ab5e8b7e30