### PR TITLE
Add single route label toggle and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,14 @@ To also render labels, use
 cat examples/stuttgart.json | loom | transitmap -l > stuttgart-label.svg
 ```
 
+When you only want to annotate interchange segments, keep labels enabled but
+omit those on single-route edges:
+
+```
+cat examples/stuttgart.json | loom | transitmap -l --single-route-labels=false \
+  > stuttgart-label-interchanges.svg
+```
+
 ### Tip: Exporting individual map layers
 
 When you need to export only a subset of the rendered features (for example,

--- a/loom.ini
+++ b/loom.ini
@@ -20,6 +20,7 @@ landmarks=../examples/landmarks_full.txt
 #   angle in radians (0-PI); values >PI treated as degrees
 # labels=false
 # route-labels=false
+# single-route-labels=true # render line labels for edges with a single route
 # line-label-textsize=40
 # line-label-bend-angle=0.349066
 # line-label-length-ratio=1.1

--- a/src/transitmap/config/ConfigReader.cpp
+++ b/src/transitmap/config/ConfigReader.cpp
@@ -97,6 +97,7 @@ constexpr int OPT_STATION_LABEL_ANGLE_STEPS = 273;
 constexpr int OPT_STATION_LABEL_ANGLE_STEP_DEG = 274;
 constexpr int OPT_TERMINUS_ANGLE_PENALTY = 275;
 constexpr int OPT_ME_STAR = 276;
+constexpr int OPT_SINGLE_ROUTE_LABELS = 277;
 bool toBool(const std::string &v) {
   std::string s = util::toLower(v);
   return s == "1" || s == "true" || s == "yes" || s == "on";
@@ -241,6 +242,9 @@ void applyOption(Config *cfg, int c, const std::string &arg,
     break;
   case 'r':
     cfg->renderRouteLabels = arg.empty() ? true : toBool(arg);
+    break;
+  case OPT_SINGLE_ROUTE_LABELS:
+    cfg->renderSingleRouteLabels = arg.empty() ? true : toBool(arg);
     break;
   case 9:
     cfg->tightStations = arg.empty() ? true : toBool(arg);
@@ -549,6 +553,8 @@ void ConfigReader::help(const char *bin) const {
       << "render labels\n"
       << std::setw(37) << "  -r [ --route-labels ]"
       << "render route names at line termini\n"
+      << std::setw(37) << "  --single-route-labels arg (=true)"
+      << "render line labels for edges with a single route\n"
       << std::setw(37) << "  --line-label-textsize arg (=40)"
       << "textsize for line labels\n"
       << std::setw(37) << "  --line-label-bend-angle arg (=0.349066)"
@@ -728,6 +734,7 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
       {"outside-penalty", 66},
       {"route-label-gap", 32},
       {"route-label-terminus-gap", 34},
+      {"single-route-labels", OPT_SINGLE_ROUTE_LABELS},
       {"terminus-label-anchor", OPT_TERMINUS_LABEL_ANCHOR},
       {"terminus-label-max-shift", OPT_TERMINUS_LABEL_MAX_SHIFT},
       {"highlight-terminal", 33},
@@ -884,6 +891,7 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
       {"outside-penalty", required_argument, 0, 66},
       {"route-label-gap", required_argument, 0, 32},
       {"route-label-terminus-gap", required_argument, 0, 34},
+      {"single-route-labels", optional_argument, 0, OPT_SINGLE_ROUTE_LABELS},
       {"terminus-label-anchor", required_argument, 0, OPT_TERMINUS_LABEL_ANCHOR},
       {"terminus-label-max-shift", required_argument, 0,
        OPT_TERMINUS_LABEL_MAX_SHIFT},

--- a/src/transitmap/config/TransitMapConfig.h
+++ b/src/transitmap/config/TransitMapConfig.h
@@ -106,6 +106,9 @@ struct Config {
   bool renderEdges = true;
   bool renderLabels = false;
   bool renderRouteLabels = false;
+  // Allow line labels to be generated for edges that carry only a single
+  // route. Disable to limit labels to multi-route edges.
+  bool renderSingleRouteLabels = true;
   bool highlightTerminals = false;
   std::string terminusHighlightFill = "black";
   std::string terminusHighlightStroke = "#BAB6B6";

--- a/src/transitmap/label/Labeller.cpp
+++ b/src/transitmap/label/Labeller.cpp
@@ -1325,6 +1325,8 @@ void Labeller::labelLines(const RenderGraph &g) {
     for (auto e : n->getAdjList()) {
       if (e->getFrom() != n)
         continue;
+      if (!_cfg->renderSingleRouteLabels && e->pl().getLines().size() <= 1)
+        continue;
       double geomLen = util::geo::len(*e->pl().getGeom());
 
       // estimate label width using precise text measurement

--- a/src/transitmap/tests/CMakeLists.txt
+++ b/src/transitmap/tests/CMakeLists.txt
@@ -2,5 +2,5 @@ include_directories(
 	${LOOM_INCLUDE_DIR}
 )
 
-add_executable(transitmapTest TestMain.cpp SanitizeSvgTest.cpp DirMarkerTest.cpp DropOverlappingStationsTest.cpp ArrowHeadDirectionTest.cpp BgMapTest.cpp LandmarkProjectionTest.cpp LandmarkSizeTest.cpp ConfigParseTest.cpp LabelPenaltyTest.cpp LandmarkDisplacementTest.cpp TerminusReverseTest.cpp StationFarCrowdTest.cpp StationLabelOptimizerTest.cpp TerminusLabelPlacementTest.cpp MeBadgeSizingTest.cpp MeBadgeRotationTest.cpp MeHighlightDisplacementTest.cpp MeBadgeCollisionTest.cpp)
+add_executable(transitmapTest TestMain.cpp SanitizeSvgTest.cpp DirMarkerTest.cpp DropOverlappingStationsTest.cpp ArrowHeadDirectionTest.cpp BgMapTest.cpp LandmarkProjectionTest.cpp LandmarkSizeTest.cpp ConfigParseTest.cpp LabelPenaltyTest.cpp LandmarkDisplacementTest.cpp TerminusReverseTest.cpp StationFarCrowdTest.cpp StationLabelOptimizerTest.cpp TerminusLabelPlacementTest.cpp MeBadgeSizingTest.cpp MeBadgeRotationTest.cpp MeHighlightDisplacementTest.cpp MeBadgeCollisionTest.cpp SingleRouteLabelTest.cpp)
 target_link_libraries(transitmapTest transitmap_dep)

--- a/src/transitmap/tests/ConfigParseTest.cpp
+++ b/src/transitmap/tests/ConfigParseTest.cpp
@@ -21,7 +21,8 @@ void ConfigParseTest::run() {
       "--displacement-cooling",      "0.5",
       "--same-side-penalty",         "42",
       "--crowding-same-side-scale",  "0.25",
-      "--reposition-label",          "2"};
+      "--reposition-label",          "2",
+      "--single-route-labels",       "false"};
   ConfigReader reader;
   int argc = static_cast<int>(sizeof(argv) / sizeof(argv[0]));
   reader.read(&cfg, argc, const_cast<char**>(argv));
@@ -39,4 +40,5 @@ void ConfigParseTest::run() {
   TEST(std::abs(cfg.sameSidePenalty - 42) < 1e-9);
   TEST(std::abs(cfg.crowdingSameSideScale - 0.25) < 1e-9);
   TEST(cfg.repositionLabel, ==, 2);
+  TEST(!cfg.renderSingleRouteLabels);
 }

--- a/src/transitmap/tests/SingleRouteLabelTest.cpp
+++ b/src/transitmap/tests/SingleRouteLabelTest.cpp
@@ -1,0 +1,86 @@
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "transitmap/tests/SingleRouteLabelTest.h"
+
+#include "shared/linegraph/LineEdgePL.h"
+#include "shared/linegraph/LineNodePL.h"
+#include "shared/rendergraph/RenderGraph.h"
+#include "transitmap/config/TransitMapConfig.h"
+#include "transitmap/label/Labeller.h"
+#include "util/Misc.h"
+#include "util/geo/Geo.h"
+
+using shared::linegraph::Line;
+using shared::linegraph::LineEdgePL;
+using shared::linegraph::LineNodePL;
+using shared::rendergraph::RenderGraph;
+using transitmapper::config::Config;
+using transitmapper::label::Labeller;
+using util::geo::DPoint;
+using util::geo::PolyLine;
+
+namespace {
+
+void buildEdgeWithLines(RenderGraph* g,
+                        std::vector<std::unique_ptr<Line>>* lines,
+                        size_t lineCount) {
+  lines->clear();
+
+  auto* nodeA = g->addNd(LineNodePL(DPoint(0.0, 0.0)));
+  auto* nodeB = g->addNd(LineNodePL(DPoint(200.0, 0.0)));
+
+  PolyLine<double> geom;
+  geom << *nodeA->pl().getGeom() << *nodeB->pl().getGeom();
+  auto* edge = g->addEdg(nodeA, nodeB, LineEdgePL(geom));
+
+  for (size_t i = 0; i < lineCount; ++i) {
+    std::string id = "L" + std::to_string(i + 1);
+    lines->emplace_back(new Line(id, id, "#000"));
+    edge->pl().addLine(lines->back().get(), nodeB);
+  }
+}
+
+}  // namespace
+
+void SingleRouteLabelTest::run() {
+  // Default behaviour labels single-route edges.
+  {
+    Config cfg;
+    RenderGraph g;
+    std::vector<std::unique_ptr<Line>> lines;
+    buildEdgeWithLines(&g, &lines, 1);
+
+    Labeller labeller(&cfg);
+    labeller.label(g, false);
+    TEST(!labeller.getLineLabels().empty());
+  }
+
+  // When disabled, single-route edges are not labelled.
+  {
+    Config cfg;
+    cfg.renderSingleRouteLabels = false;
+    RenderGraph g;
+    std::vector<std::unique_ptr<Line>> lines;
+    buildEdgeWithLines(&g, &lines, 1);
+
+    Labeller labeller(&cfg);
+    labeller.label(g, false);
+    TEST(labeller.getLineLabels().empty());
+  }
+
+  // Multi-route edges remain eligible when the flag is disabled.
+  {
+    Config cfg;
+    cfg.renderSingleRouteLabels = false;
+    RenderGraph g;
+    std::vector<std::unique_ptr<Line>> lines;
+    buildEdgeWithLines(&g, &lines, 2);
+
+    Labeller labeller(&cfg);
+    labeller.label(g, false);
+    TEST(!labeller.getLineLabels().empty());
+    TEST(labeller.getLineLabels()[0].lines.size(), ==, 2);
+  }
+}

--- a/src/transitmap/tests/SingleRouteLabelTest.h
+++ b/src/transitmap/tests/SingleRouteLabelTest.h
@@ -1,0 +1,9 @@
+#ifndef TRANSITMAP_TEST_SINGLEROUTELABELTEST_H_
+#define TRANSITMAP_TEST_SINGLEROUTELABELTEST_H_
+
+class SingleRouteLabelTest {
+ public:
+  void run();
+};
+
+#endif  // TRANSITMAP_TEST_SINGLEROUTELABELTEST_H_

--- a/src/transitmap/tests/TestMain.cpp
+++ b/src/transitmap/tests/TestMain.cpp
@@ -20,6 +20,7 @@
 #include "transitmap/tests/StationLabelOptimizerTest.h"
 #include "transitmap/tests/TerminusLabelPlacementTest.h"
 #include "transitmap/tests/TerminusReverseTest.h"
+#include "transitmap/tests/SingleRouteLabelTest.h"
 
 // _____________________________________________________________________________
 int main(int argc, char** argv) {
@@ -61,5 +62,7 @@ int main(int argc, char** argv) {
   tlpt.run();
   TerminusReverseTest trt;
   trt.run();
+  SingleRouteLabelTest srlt;
+  srlt.run();
   return 0;
 }


### PR DESCRIPTION
## Summary
- add a renderSingleRouteLabels config flag with CLI support and documentation
- conditionally skip line-label generation on single-route edges when disabled
- cover the new option with config parsing and labeller regression tests
- describe the single-route label toggle in the README usage examples

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6555ba8dc832d968b746ab352a86d