### PR TITLE
Use render graph metrics for clique offsets

### DIFF
--- a/src/transitmap/output/SvgRenderer.h
+++ b/src/transitmap/output/SvgRenderer.h
@@ -150,6 +150,7 @@ class SvgRenderer : public Renderer {
       std::vector<shared::rendergraph::InnerGeom> geoms, size_t level) const;
 
   void renderClique(const InnerClique& c,
+                    const shared::rendergraph::RenderGraph& graph,
                     const shared::linegraph::LineNode* node);
 
   bool isNextTo(const shared::rendergraph::InnerGeom& a,

--- a/src/transitmap/tests/InnerGeomLaneOrderTest.cpp
+++ b/src/transitmap/tests/InnerGeomLaneOrderTest.cpp
@@ -92,7 +92,7 @@ void InnerGeomLaneOrderTest::run() {
   TEST(slotPairs.size(), ==, 2);
   TEST(targetClique, !=, nullptr);
 
-  renderer.renderClique(*targetClique, left);
+  renderer.renderClique(*targetClique, graph, left);
 
   TEST(renderer._innerDelegates.empty(), ==, false);
   const auto& delegateMap = renderer._innerDelegates.back();


### PR DESCRIPTION
## Summary
- extend `renderClique` to accept the render graph so it can inspect per-edge lane metrics
- derive inner-clique offset distances from the render graph before applying the reference offset
- update the lane-order unit test to call the new signature

## Testing
- cmake -S . -B build *(fails: missing src/cppgtfs CMakeLists.txt)*

------
https://chatgpt.com/codex/tasks/task_e_68d6bb57599c832db1c1209c3c0042ef