### PR TITLE
Handle reversing inner geometries

### DIFF
--- a/src/shared/rendergraph/RenderGraph.h
+++ b/src/shared/rendergraph/RenderGraph.h
@@ -113,6 +113,11 @@ private:
                const shared::linegraph::Partner &partnerFrom,
                const shared::linegraph::Partner &partnerTo) const;
 
+  shared::rendergraph::InnerGeom getReversingLine(
+      const shared::linegraph::LineNode *n,
+      const shared::linegraph::Partner &partnerFrom,
+      const shared::linegraph::Partner &partnerTo) const;
+
   shared::rendergraph::InnerGeom
   getTerminusLine(const shared::linegraph::LineNode *n,
                   const shared::linegraph::Partner &partnerFrom) const;


### PR DESCRIPTION
## Summary
- add a RenderGraph helper to generate inner geometry for reversing lines
- enqueue reversing partners in innerGeoms with the expected slot metadata so they are rendered

## Testing
- `cmake --build . --target transitmap -j$(nproc)`
- `cat reverse_case.json | ./transitmap > reverse.svg`
- `rg "inner-geom" -n reverse.svg`


------
https://chatgpt.com/codex/tasks/task_e_68d6b9f60118832db503ba07c20cde0d