### PR TITLE
Add ostream helper for nullptr in test macros

### DIFF
--- a/src/util/Misc.h
+++ b/src/util/Misc.h
@@ -21,6 +21,10 @@
 #include "3rdparty/dtoa_milo.h"
 #include "util/String.h"
 
+inline std::ostream& operator<<(std::ostream& out, std::nullptr_t) {
+  return out << "nullptr";
+}
+
 #define UNUSED(expr) do { (void)(expr); } while (0)
 #define TIME() std::chrono::high_resolution_clock::now()
 #define TOOK(t1, t2) (std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count() / 1000.0)


### PR DESCRIPTION
## Summary
- add an ostream overload for std::nullptr_t so test macros stream nullptr deterministically

## Testing
- g++ -std=c++11 -Isrc -Isrc/3rdparty -c src/transitmap/tests/InnerGeomLaneOrderTest.cpp -o /tmp/InnerGeomLaneOrderTest.o

------
https://chatgpt.com/codex/tasks/task_e_68d6c2d341d8832d96f02ffa32917195