### PR TITLE
Ensure deterministic edge ordering

### DIFF
--- a/src/loom/optim/OptGraph.cpp
+++ b/src/loom/optim/OptGraph.cpp
@@ -1797,7 +1797,8 @@ void OptGraph::updateEdgeOrder(OptNode* n) {
   for (auto e : n->getAdjList()) {
     n->pl().circOrdering.push_back(e);
   }
-  std::sort(n->pl().circOrdering.begin(), n->pl().circOrdering.end(), cmpEdge);
+  std::stable_sort(n->pl().circOrdering.begin(), n->pl().circOrdering.end(),
+                   cmpEdge);
 
   for (size_t i = 0; i < n->pl().circOrdering.size(); i++) {
     n->pl().circOrderMap[n->pl().circOrdering[i]] = i;


### PR DESCRIPTION
## Summary
- replace the circular adjacency ordering sort with std::stable_sort so equal-angle edges keep their previous order

## Testing
- cmake -S . -B build *(fails: missing cppgtfs submodule because the repository cannot be downloaded in this environment)*
- git submodule update --init --recursive *(fails: remote repository blocked by environment restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d75dfe0190832d8a7c378aa57dbaa8