### PR TITLE
Add flag to keep station label font size constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,8 @@ Command-line parameters
 * `--line-label-bend-angle <rad>`: max bend angle in radians for line label candidates (default `0.349066`).
 * `--line-label-length-ratio <ratio>`: max length/straight distance ratio for line label candidates (default `1.1`).
 * `--station-label-textsize <size>`: text size for station labels (default `60`).
+* `--station-label-textsize-constant`: treat the station label text size as a
+  constant pixel value regardless of `--resolution` (default off).
 * `--me-label-textsize <size>`: text size for "YOU ARE HERE" label (default `80`).
 * `--font-svg-max <size>`: max font size for station labels in SVG, -1 for no limit (default `11`).
 * `--station-line-overlap-penalty <weight>`: penalty multiplier for station-line overlaps (default `15`).

--- a/loom.ini
+++ b/loom.ini
@@ -24,6 +24,7 @@ landmarks=../examples/landmarks_full.txt
 # line-label-bend-angle=0.349066
 # line-label-length-ratio=1.1
 # station-label-textsize=60
+# station-label-textsize-constant=false
 # me-label-textsize=80
 # font-svg-max=11
 # station-line-overlap-penalty=15

--- a/src/transitmap/config/ConfigReader.cpp
+++ b/src/transitmap/config/ConfigReader.cpp
@@ -98,6 +98,7 @@ constexpr int OPT_STATION_LABEL_ANGLE_STEP_DEG = 274;
 constexpr int OPT_TERMINUS_ANGLE_PENALTY = 275;
 constexpr int OPT_ME_STAR = 276;
 constexpr int OPT_SINGLE_ROUTE_LABELS = 277;
+constexpr int OPT_STATION_LABEL_TEXTSIZE_CONSTANT = 278;
 bool toBool(const std::string &v) {
   std::string s = util::toLower(v);
   return s == "1" || s == "true" || s == "yes" || s == "on";
@@ -146,6 +147,9 @@ void applyOption(Config *cfg, int c, const std::string &arg,
     break;
   case 6:
     cfg->stationLabelSize = atof(arg.c_str());
+    break;
+  case OPT_STATION_LABEL_TEXTSIZE_CONSTANT:
+    cfg->stationLabelTextSizeConstant = arg.empty() ? true : toBool(arg);
     break;
   case OPT_STATION_LABEL_ANGLE_STEPS: {
     int steps = atoi(arg.c_str());
@@ -558,6 +562,8 @@ void ConfigReader::help(const char *bin) const {
       << "max length/straight distance ratio for line label candidates\n"
       << std::setw(37) << "  --station-label-textsize arg (=60)"
       << "textsize for station labels\n"
+      << std::setw(37) << "  --station-label-textsize-constant[=<bool>]"
+      << "treat station label text size as constant pixel size\n"
       << std::setw(37) << "  --station-label-angle-steps arg (=24)"
       << "number of station label orientations to sample\n"
       << std::setw(37)
@@ -711,6 +717,7 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
       {"line-label-bend-angle", 35},
       {"line-label-length-ratio", 36},
       {"station-label-textsize", 6},
+      {"station-label-textsize-constant", OPT_STATION_LABEL_TEXTSIZE_CONSTANT},
       {"station-label-angle-steps", OPT_STATION_LABEL_ANGLE_STEPS},
       {"station-label-angle-step-deg", OPT_STATION_LABEL_ANGLE_STEP_DEG},
       {"me-label-textsize", 40},
@@ -861,6 +868,8 @@ void ConfigReader::read(Config *cfg, int argc, char **argv) const {
       {"line-label-bend-angle", required_argument, 0, 35},
       {"line-label-length-ratio", required_argument, 0, 36},
       {"station-label-textsize", required_argument, 0, 6},
+      {"station-label-textsize-constant", optional_argument, 0,
+       OPT_STATION_LABEL_TEXTSIZE_CONSTANT},
       {"station-label-angle-steps", required_argument, 0,
        OPT_STATION_LABEL_ANGLE_STEPS},
       {"station-label-angle-step-deg", required_argument, 0,

--- a/src/transitmap/config/TransitMapConfig.h
+++ b/src/transitmap/config/TransitMapConfig.h
@@ -33,6 +33,7 @@ struct Config {
   // Maximum allowed ratio of polyline length to straight-line distance.
   double lineLabelLengthRatio = 1.1;
   double stationLabelSize = 60;
+  bool stationLabelTextSizeConstant = false;
   // Number of discrete station label orientations sampled around a node.
   size_t stationLabelAngleSteps = 24;
   // Step size in degrees between successive station label orientations.
@@ -176,6 +177,16 @@ struct Config {
   Landmark meLandmark;
 
   int logLevel = INFO;
+
+  double stationLabelFontSizeMapUnits() const {
+    double res = outputResolution > 0.0 ? outputResolution : 1.0;
+    return stationLabelTextSizeConstant ? stationLabelSize / res : stationLabelSize;
+  }
+
+  double stationLabelFontSizePx() const {
+    double res = outputResolution > 0.0 ? outputResolution : 1.0;
+    return stationLabelTextSizeConstant ? stationLabelSize : stationLabelSize * res;
+  }
 };
 
 } // namespace config

--- a/src/transitmap/label/Labeller.cpp
+++ b/src/transitmap/label/Labeller.cpp
@@ -121,7 +121,7 @@ std::pair<double, double> getLandmarkSizeMapUnits(
     return {0.0, 0.0};
   }
 
-  double maxWidthPx = cfg->stationLabelSize * cfg->outputResolution * 0.6 * 10.0;
+  double maxWidthPx = cfg->stationLabelFontSizePx() * 0.6 * 10.0;
   double widthPx = lm.size * cfg->outputResolution;
   double heightPx = widthPx;
 
@@ -735,7 +735,7 @@ void Labeller::labelStations(const RenderGraph &g, bool notdeg2) {
   const double terminusAnglePenalty = getTerminusAnglePenalty(_cfg);
 
   for (auto n : orderedNds) {
-    double fontSize = _cfg->stationLabelSize;
+    double fontSize = _cfg->stationLabelFontSizeMapUnits();
     bool isTerminus = g.isTerminus(n);
     if (_cfg->highlightTerminals && isTerminus) {
       fontSize += 10;
@@ -777,7 +777,7 @@ void Labeller::labelStations(const RenderGraph &g, bool notdeg2) {
         double diag = util::geo::dist(box.getLowerLeft(), box.getUpperRight());
         double searchRad =
             g.getMaxLineNum() * (_cfg->lineWidth + _cfg->lineSpacing) +
-            std::max(_cfg->stationLabelSize, diag);
+            std::max(_cfg->stationLabelFontSizeMapUnits(), diag);
 
         auto overlaps = getOverlaps(band, n, g, searchRad);
 
@@ -952,7 +952,7 @@ void Labeller::labelStations(const RenderGraph &g, bool notdeg2) {
     double diag = util::geo::dist(box.getLowerLeft(), box.getUpperRight());
     double searchRad =
         g.getMaxLineNum() * (_cfg->lineWidth + _cfg->lineSpacing) +
-        std::max(_cfg->stationLabelSize, diag);
+        std::max(_cfg->stationLabelFontSizeMapUnits(), diag);
 
     auto overlaps = getOverlaps(flippedBand, n, g, searchRad);
 
@@ -1166,7 +1166,7 @@ void Labeller::repositionStationLabels(const RenderGraph &g) {
         double diag = util::geo::dist(box.getLowerLeft(), box.getUpperRight());
         double searchRad = g.getMaxLineNum() *
                                (_cfg->lineWidth + _cfg->lineSpacing) +
-                           std::max(_cfg->stationLabelSize, diag);
+                           std::max(_cfg->stationLabelFontSizeMapUnits(), diag);
 
         auto overlaps = getOverlaps(band, n, g, searchRad);
 

--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -141,7 +141,7 @@ bool sanitizeSvg(std::string &s) {
 std::pair<double, double> getLandmarkSizePx(const Landmark &lm,
                                             const Config *cfg) {
   // Compute the maximum allowed width in pixels.
-  double maxWidth = cfg->stationLabelSize * cfg->outputResolution * 0.6 *
+  double maxWidth = cfg->stationLabelFontSizePx() * 0.6 *
                     10.0; // "__________"
 
   if (!lm.iconPath.empty()) {
@@ -2587,7 +2587,7 @@ void SvgRenderer::renderTerminusLabels(const RenderGraph &g,
       const auto &top = sLbl->band[2];
       double baseX = base[0].getX();
       double baseY = base[0].getY();
-      double scale = sLbl->fontSize / _cfg->stationLabelSize;
+      double scale = sLbl->fontSize / _cfg->stationLabelFontSizeMapUnits();
 
       for (const auto &ln : sLbl->band) {
         for (const auto &p : ln) {

--- a/src/transitmap/tests/LandmarkSizeTest.cpp
+++ b/src/transitmap/tests/LandmarkSizeTest.cpp
@@ -41,7 +41,7 @@ void LandmarkSizeTest::run() {
   lm.label = "Hello";  // 5 characters
   lm.fontSize = 200.0; // yields width greater than maxWidth
   dims = getLandmarkSizePx(lm, &cfg);
-  double maxWidth = cfg.stationLabelSize * cfg.outputResolution * 0.6 * 10.0;
+  double maxWidth = cfg.stationLabelFontSizePx() * 0.6 * 10.0;
   double w = util::toWStr(lm.label).size() * (lm.fontSize * 0.6);
   double f = maxWidth / w;
   expectedW = maxWidth;

--- a/src/transitmap/tests/MeBadgeCollisionTest.cpp
+++ b/src/transitmap/tests/MeBadgeCollisionTest.cpp
@@ -68,7 +68,7 @@ void MeBadgeCollisionTest::run() {
   controlCfg.highlightMeStationLabel = false;
   Labeller controlLabeller(&controlCfg);
   auto baseBand = controlLabeller.getStationLblBand(
-      bandNode, baseCfg.stationLabelSize, 0, gBand);
+      bandNode, baseCfg.stationLabelFontSizeMapUnits(), 0, gBand);
 
   Config badgeCfg = baseCfg;
   badgeCfg.meStation = util::sanitizeStationLabel("Here");
@@ -78,7 +78,7 @@ void MeBadgeCollisionTest::run() {
   badgeCfg.highlightMeStationLabel = true;
   Labeller badgeLabeller(&badgeCfg);
   auto badgeBand = badgeLabeller.getStationLblBand(
-      bandNode, badgeCfg.stationLabelSize, 0, gBand);
+      bandNode, badgeCfg.stationLabelFontSizeMapUnits(), 0, gBand);
 
   TEST(!baseBand.empty());
   TEST(!badgeBand.empty());

--- a/src/transitmap/tests/StationFarCrowdTest.cpp
+++ b/src/transitmap/tests/StationFarCrowdTest.cpp
@@ -140,8 +140,8 @@ void StationFarCrowdTest::run() {
     neighborBand.push_back(neighbor);
 
     Labeller labeller(&cfg);
-    LabellerFarCrowdTestAccess::addSyntheticLabel(labeller, neighborBand,
-                                                  cfg.stationLabelSize);
+    LabellerFarCrowdTestAccess::addSyntheticLabel(
+        labeller, neighborBand, cfg.stationLabelFontSizeMapUnits());
     auto ctx = LabellerFarCrowdTestAccess::computeContext(labeller, band,
                                                           station, searchRadius, g);
     TEST(std::abs(ctx.farCrowdPen - cfg.stationLabelFarCrowdPenalty) < 1e-9);

--- a/src/transitmap/tests/TerminusLabelPlacementTest.cpp
+++ b/src/transitmap/tests/TerminusLabelPlacementTest.cpp
@@ -131,7 +131,7 @@ void TerminusLabelPlacementTest::run() {
     Labeller labeller(&cfg);
     labeller._stationLabels.clear();
     labeller._stationLabels.emplace_back(
-        labelGeom, band, cfg.stationLabelSize, false, 0, 0, overlaps, 0.0,
+        labelGeom, band, cfg.stationLabelFontSizeMapUnits(), false, 0, 0, overlaps, 0.0,
         cfg.stationLineOverlapPenalty, 0.0, 0.0, false, 1.0, 0.0, nullptr,
         stop);
 


### PR DESCRIPTION
## Summary
- add a configuration flag to treat station label text sizes as constant pixel values
- update layout, rendering, and docs/tests to use the constant size helper functions when enabled

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fb4c25eef4832d8cda213b1b0ed209