### PR TITLE
Use point units for constant station labels

### DIFF
--- a/src/transitmap/config/TransitMapConfig.h
+++ b/src/transitmap/config/TransitMapConfig.h
@@ -27,6 +27,16 @@ struct Config {
   double lineWidth = 20;
   double lineSpacing = 10;
 
+  static constexpr double kCssPixelsPerPoint = 96.0 / 72.0;
+
+  static double pointsToCssPixels(double points) {
+    return points * kCssPixelsPerPoint;
+  }
+
+  static double cssPixelsToPoints(double pixels) {
+    return pixels / kCssPixelsPerPoint;
+  }
+
   double lineLabelSize = 40;
   // Maximum allowed bend angle in radians for line label candidates.
   double lineLabelBendAngle = 0.3490658503988659; // ~20 degrees
@@ -180,12 +190,18 @@ struct Config {
 
   double stationLabelFontSizeMapUnits() const {
     double res = outputResolution > 0.0 ? outputResolution : 1.0;
-    return stationLabelTextSizeConstant ? stationLabelSize / res : stationLabelSize;
+    if (stationLabelTextSizeConstant) {
+      return pointsToCssPixels(stationLabelSize) / res;
+    }
+    return stationLabelSize;
   }
 
   double stationLabelFontSizePx() const {
     double res = outputResolution > 0.0 ? outputResolution : 1.0;
-    return stationLabelTextSizeConstant ? stationLabelSize : stationLabelSize * res;
+    if (stationLabelTextSizeConstant) {
+      return pointsToCssPixels(stationLabelSize);
+    }
+    return stationLabelSize * res;
   }
 };
 

--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -92,6 +92,14 @@ constexpr double kBadgeStarPathCenterY = 15.181585;
 constexpr double kBadgeStarPathWidth = 17.91695;
 constexpr double kBadgeStarPathHeight = 16.89343;
 
+std::string formatStationLabelFontSize(const Config &cfg, double fontSizePx) {
+  if (cfg.stationLabelTextSizeConstant) {
+    double fontSizePt = Config::cssPixelsToPoints(fontSizePx);
+    return util::toString(fontSizePt) + "pt";
+  }
+  return util::toString(fontSizePx);
+}
+
 }  // namespace
 
 // Remove XML or DOCTYPE declarations and strip potentially dangerous
@@ -1288,10 +1296,11 @@ void SvgRenderer::renderMe(const RenderGraph &g, Labeller &labeller,
     textAttrs["alignment-baseline"] = "middle";
     textAttrs["fill"] = _cfg->meStationTextColor;
     textAttrs["font-family"] = "TT Norms Pro";
+    double highlightFontSizePx =
+        highlightInfo.fontSizePx > 0.0 ? highlightInfo.fontSizePx
+                                       : textHeightForPadding;
     textAttrs["font-size"] =
-        util::toString(highlightInfo.fontSizePx > 0.0
-                           ? highlightInfo.fontSizePx
-                           : textHeightForPadding);
+        formatStationLabelFontSize(*_cfg, highlightFontSizePx);
     textAttrs["font-weight"] = highlightInfo.bold ? "bold" : "normal";
     _w.openTag("text", textAttrs);
     _w.writeText(label->s.name);
@@ -2318,7 +2327,7 @@ void SvgRenderer::renderStationLabels(const Labeller &labeller,
     double fontSize = label.fontSize * _cfg->outputResolution;
     if (_cfg->fontSvgMax >= 0 && fontSize > _cfg->fontSvgMax)
       fontSize = _cfg->fontSvgMax;
-    params["font-size"] = util::toString(fontSize);
+    params["font-size"] = formatStationLabelFontSize(*_cfg, fontSize);
 
     bool isMeLabel = false;
     if (wantHighlight && _meStationLabelVisual.isNull()) {


### PR DESCRIPTION
## Summary
- convert constant station label sizing logic to interpret values as CSS points when constant sizing is enabled
- emit station label SVG font sizes in pt while keeping layout calculations consistent with the converted pixel size

## Testing
- cmake -S . -B build *(fails: /workspace/loom/src/cppgtfs missing CMakeLists.txt)*

------
https://chatgpt.com/codex/tasks/task_e_690043c79f98832daa500c3506bc87a0