### PR TITLE
Revert Merge pull request #272 from timbold/codex/replace-std-sort-with-std-stable_sort

### DIFF
--- a/src/loom/optim/OptGraph.cpp
+++ b/src/loom/optim/OptGraph.cpp
@@ -1797,8 +1797,7 @@ void OptGraph::updateEdgeOrder(OptNode* n) {
   for (auto e : n->getAdjList()) {
     n->pl().circOrdering.push_back(e);
   }
-  std::stable_sort(n->pl().circOrdering.begin(), n->pl().circOrdering.end(),
-                   cmpEdge);
+  std::sort(n->pl().circOrdering.begin(), n->pl().circOrdering.end(), cmpEdge);
 
   for (size_t i = 0; i < n->pl().circOrdering.size(); i++) {
     n->pl().circOrderMap[n->pl().circOrdering[i]] = i;


### PR DESCRIPTION
## Summary
- revert the change from PR #272 so OptGraph::updateEdgeOrder once again uses std::sort rather than std::stable_sort
- this restores the edge-ordering behavior that predated PR #272; PR #273 was previously reverted and requires no further changes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69004b93e004832daa2a638153cacbaf