### PR TITLE
Fix station label text size clamp when text size is constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,9 @@ Command-line parameters
   spacing as constant typographic point values regardless of `--resolution`
   (default off).
 * `--me-label-textsize <size>`: text size for "YOU ARE HERE" label (default `80`).
-* `--font-svg-max <size>`: max font size for station labels in SVG, -1 for no limit (default `11`).
+* `--font-svg-max <size>`: max font size for station labels in SVG, -1 for no
+  limit (default `11`). The value is interpreted as typographic points when
+  `--textsize-constant` is active and as SVG pixels otherwise.
 * `--station-line-overlap-penalty <weight>`: penalty multiplier for station-line overlaps (default `15`).
 * `--station-line-overlap-per-line`: count distinct transit lines when scoring station-line overlaps (default disabled).
 * `--station-label-far-crowd-radius <px>`: radius from the far end of a station label used to look for nearby edges, existing labels, station hulls, and landmark boxes (default `0`, disables).

--- a/src/transitmap/config/TransitMapConfig.h
+++ b/src/transitmap/config/TransitMapConfig.h
@@ -227,6 +227,25 @@ struct Config {
     }
     return routeLabelTerminusGap * res;
   }
+
+  double fontSvgMaxPx() const {
+    if (fontSvgMax < 0) {
+      return fontSvgMax;
+    }
+    if (textSizeConstant) {
+      return pointsToCssPixels(fontSvgMax);
+    }
+    return fontSvgMax;
+  }
+
+  double fontSvgMaxMapUnits() const {
+    double maxPx = fontSvgMaxPx();
+    if (maxPx < 0) {
+      return maxPx;
+    }
+    double res = outputResolution > 0.0 ? outputResolution : 1.0;
+    return maxPx / res;
+  }
 };
 
 } // namespace config

--- a/src/transitmap/label/Labeller.cpp
+++ b/src/transitmap/label/Labeller.cpp
@@ -740,9 +740,9 @@ void Labeller::labelStations(const RenderGraph &g, bool notdeg2) {
     if (_cfg->highlightTerminals && isTerminus) {
       fontSize += 10;
     }
-    if (_cfg->fontSvgMax >= 0 &&
-        fontSize * _cfg->outputResolution > _cfg->fontSvgMax) {
-      fontSize = _cfg->fontSvgMax / _cfg->outputResolution;
+    double fontSvgMax = _cfg->fontSvgMaxMapUnits();
+    if (fontSvgMax >= 0 && fontSize > fontSvgMax) {
+      fontSize = fontSvgMax;
     }
     int prefDeg = 0;
     if (n->pl().stops().size()) {

--- a/src/transitmap/output/SvgRenderer.cpp
+++ b/src/transitmap/output/SvgRenderer.cpp
@@ -2324,8 +2324,9 @@ void SvgRenderer::renderStationLabels(const Labeller &labeller,
     params["font-family"] = "TT Norms Pro";
     params["dy"] = shift;
     double fontSize = label.fontSize * _cfg->outputResolution;
-    if (_cfg->fontSvgMax >= 0 && fontSize > _cfg->fontSvgMax)
-      fontSize = _cfg->fontSvgMax;
+    double fontSvgMax = _cfg->fontSvgMaxPx();
+    if (fontSvgMax >= 0 && fontSize > fontSvgMax)
+      fontSize = fontSvgMax;
     params["font-size"] = formatFontSize(*_cfg, fontSize);
 
     bool isMeLabel = false;


### PR DESCRIPTION
## Summary
- convert the font-svg-max limit into consistent pixel/point units when text sizes are constant
- reuse the new helpers when clamping station label font sizes in the labeller and SVG renderer
- document how font-svg-max is interpreted with and without --textsize-constant

## Testing
- cmake -S . -B build *(fails: src/cppgtfs missing CMakeLists.txt)*

------
https://chatgpt.com/codex/tasks/task_e_69006a1e46a0832d8a4492bc74cd9d0e