### PR TITLE
Improve optimizer stability for complex networks

### DIFF
--- a/src/loom/LoomMain.cpp
+++ b/src/loom/LoomMain.cpp
@@ -4,6 +4,9 @@
 
 #include <stdio.h>
 #include <unistd.h>
+#include <algorithm>
+#include <chrono>
+#include <limits>
 #include <fstream>
 #include <iostream>
 #include <set>
@@ -24,13 +27,27 @@ using namespace loom;
 
 // _____________________________________________________________________________
 int main(int argc, char** argv) {
-  // initialize randomness
-  srand(time(NULL) + rand());
-
   config::Config cfg;
 
   config::ConfigReader cr;
   cr.read(&cfg, argc, argv);
+
+  const bool seedProvided = cfg.randomSeed >= 0;
+  unsigned int seed = 0;
+  if (seedProvided) {
+    seed = static_cast<unsigned int>(cfg.randomSeed);
+  } else {
+    seed = static_cast<unsigned int>(
+        std::chrono::steady_clock::now().time_since_epoch().count());
+    seed %= static_cast<unsigned int>(std::numeric_limits<int>::max());
+  }
+
+  srand(seed);
+  cfg.randomSeed = static_cast<int>(seed);
+
+  LOGTO(DEBUG, std::cerr)
+      << "Using random seed " << seed
+      << (seedProvided ? " (user provided)" : " (auto generated)");
 
   LOGTO(DEBUG, std::cerr) << "Reading graph...";
   shared::rendergraph::RenderGraph g(5, 1, 5);

--- a/src/loom/config/ConfigReader.cpp
+++ b/src/loom/config/ConfigReader.cpp
@@ -3,6 +3,7 @@
 // Authors: Patrick Brosi <brosi@informatik.uni-freiburg.de>
 
 #include <getopt.h>
+#include <iomanip>
 #include <iostream>
 #include <string>
 #include "loom/_config.h"
@@ -78,7 +79,11 @@ void ConfigReader::help(const char* bin) const {
             << std::setw(43) << "  --dbg-output-path arg (=.)"
             << "Path used for debug output\n"
             << std::setw(43) << "  --output-optgraph"
-            << "Output optimization graph to debug path\n";
+            << "Output optimization graph to debug path\n"
+            << std::setw(43) << "  --random-seed arg"
+            << "Seed used for randomized optimizers\n"
+            << std::setw(43) << "  --no-auto-optim-runs"
+            << "Disable automatic scaling of --optim-runs\n";
 }
 
 // _____________________________________________________________________________
@@ -92,7 +97,7 @@ void ConfigReader::read(Config* cfg, int argc, char** argv) const {
       {"same-seg-cross-pen", required_argument, 0, 4},
       {"diff-seg-cross-pen", required_argument, 0, 9},
       {"sep-pen", required_argument, 0, 5},
-      {"from-dot", required_argument, 0, 'D'},
+      {"from-dot", no_argument, 0, 'D'},
       {"in-stat-sep-pen", required_argument, 0, 8},
       {"in-stat-cross-pen-same-seg", required_argument, 0, 6},
       {"in-stat-cross-pen-diff-seg", required_argument, 0, 7},
@@ -102,8 +107,10 @@ void ConfigReader::read(Config* cfg, int argc, char** argv) const {
       {"optim-method", required_argument, 0, 'm'},
       {"optim-runs", required_argument, 0, 13},
       {"dbg-output-path", required_argument, 0, 14},
-      {"output-optgraph", required_argument, 0, 15},
+      {"output-optgraph", no_argument, 0, 15},
       {"write-stats", no_argument, 0, 16},
+      {"no-auto-optim-runs", no_argument, 0, 17},
+      {"random-seed", required_argument, 0, 18},
       {0, 0, 0, 0}};
 
   int c;
@@ -165,6 +172,12 @@ void ConfigReader::read(Config* cfg, int argc, char** argv) const {
         break;
       case 16:
         cfg->writeStats = true;
+        break;
+      case 17:
+        cfg->autoScaleOptimRuns = false;
+        break;
+      case 18:
+        cfg->randomSeed = atoi(optarg);
         break;
       case 'D':
         cfg->fromDot = true;

--- a/src/loom/config/LoomConfig.h
+++ b/src/loom/config/LoomConfig.h
@@ -19,6 +19,7 @@ struct Config {
   std::string MPSOutputPath;
 
   size_t optimRuns = 1;
+  bool autoScaleOptimRuns = true;
 
   bool outOptGraph = false;
 
@@ -31,6 +32,8 @@ struct Config {
 
   int ilpTimeLimit = -1;
   int ilpNumThreads = 0;
+
+  int randomSeed = -1;
 
   double crossPenMultiSameSeg = 4;
   double crossPenMultiDiffSeg = 1;

--- a/src/loom/optim/Optimizer.cpp
+++ b/src/loom/optim/Optimizer.cpp
@@ -2,6 +2,7 @@
 // Chair of Algorithms and Data Structures.
 // Authors: Patrick Brosi <brosi@informatik.uni-freiburg.de>
 
+#include <algorithm>
 #include <fstream>
 #include <numeric>
 #include "loom/optim/NullOptimizer.h"
@@ -140,6 +141,25 @@ OptResStats Optimizer::optimize(RenderGraph* rg) const {
   }
 
   size_t runs = _cfg->optimRuns;
+  if (_cfg->autoScaleOptimRuns) {
+    size_t complexity =
+        std::max(optResStats.maxLineCard, optResStats.maxDegOrig);
+    size_t recommendedRuns = 1;
+    if (complexity >= 9) {
+      recommendedRuns = 10;
+    } else if (complexity >= 7) {
+      recommendedRuns = 6;
+    } else if (complexity >= 5) {
+      recommendedRuns = 3;
+    }
+
+    if (recommendedRuns > runs) {
+      LOGTO(DEBUG, std::cerr)
+          << "Auto-scaling optimization runs to " << recommendedRuns
+          << " based on complexity metric " << complexity;
+      runs = recommendedRuns;
+    }
+  }
   double tSum = 0;
   double scoreSum = 0;
   double crossSum = 0;

--- a/src/loom/tests/TestMain.cpp
+++ b/src/loom/tests/TestMain.cpp
@@ -427,6 +427,7 @@ int main(int argc, char** argv) {
   baseCfg.untangleGraph = false;
   baseCfg.pruneGraph = false;
   baseCfg.optimRuns = 1;
+  baseCfg.autoScaleOptimRuns = false;
 
   shared::rendergraph::Penalties pens{1, 0, 1, 1, 0, 1, 1, 0, false, false};
 


### PR DESCRIPTION
## Summary
- expose a `--random-seed` option and fix flag parsing for `--from-dot`/`--output-optgraph`
- add an auto-scaling heuristic for `--optim-runs` with a disable switch and debug logging
- ensure tests remain deterministic by disabling auto-scaling in the harness

## Testing
- cmake -S . -B build *(fails: missing optional cppgtfs subdirectory CMakeLists.txt)*

------
https://chatgpt.com/codex/tasks/task_e_690371c52b80832d8e75ed99c8a7ead8